### PR TITLE
build(deps): bump alpine image from 3.19.1 to 3.20.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,12 @@ container_ids=`buildah ls --format "{{.ContainerID}}"`
 # default setttings for official curl images
 debian_base=docker.io/debian
 fedora_base=docker.io/fedora
-base=docker.io/alpine:3.19.1
+base=docker.io/alpine:3.20.0
 arch=""
 compiler="gcc"
 build_opts=" --enable-static --disable-ldap --enable-ipv6 --enable-unix-sockets -with-ssl --with-libssh2 --with-nghttp2=/usr --with-gssapi"
-dev_deps="git zsh libssh2 libssh2-dev libssh2-static autoconf automake build-base groff openssl curl-dev python3 python3-dev libtool curl stunnel perl nghttp2 brotli brotli-dev krb5-dev libpsl-dev"
-base_deps="brotli brotli-dev libssh2 nghttp2-dev libidn2 krb5 libpsl"
+dev_deps="git zsh libssh2 libssh2-dev libssh2-static autoconf automake build-base groff openssl curl-dev python3 python3-dev libtool curl stunnel perl nghttp2 brotli brotli-dev krb5-dev libpsl-dev zstd-libs"
+base_deps="brotli brotli-dev libssh2 nghttp2-dev libidn2 krb5 libpsl zstd-libs"
 
 ##############################################
 # debian dev image


### PR DESCRIPTION
It seems the alpine 3.20.x doesn't have zstd-libs installed, it throws exceptions when executing curl. 
```
2024-05-23T08:13:10.704404444Z stderr F Error loading shared library libzstd.so.1: No such file or directory (needed by /usr/lib/libcurl.so.4)
2024-05-23T08:13:10.705115853Z stderr F Error relocating /usr/lib/libcurl.so.4: ZSTD_isError: symbol not found
2024-05-23T08:13:10.70521585Z stderr F Error relocating /usr/lib/libcurl.so.4: ZSTD_createDStream: symbol not found
2024-05-23T08:13:10.705227151Z stderr F Error relocating /usr/lib/libcurl.so.4: ZSTD_decompressStream: symbol not found
2024-05-23T08:13:10.705265631Z stderr F Error relocating /usr/lib/libcurl.so.4: ZSTD_freeDStream: symbol not found
2024-05-23T08:13:10.705346903Z stderr F Error relocating /usr/lib/libcurl.so.4: ZSTD_versionNumber: symbol not found
```

The PR is to resolve it and bump alpine to 3.20.0.