### PR TITLE
ci: set permissions, pin actions, do not persists creds, add `SECURITY.md`

### DIFF
--- a/.github/workflows/build_ci_multi.yml
+++ b/.github/workflows/build_ci_multi.yml
@@ -33,7 +33,9 @@ jobs:
           podman login -u ${{secrets.QUAY_USER}} -p ${{secrets.QUAY_TOKEN}} quay.io
           docker login -u ${{secrets.QUAY_USER}} -p ${{secrets.QUAY_TOKEN}} quay.io
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        with:
+          persist-credentials: false
       - run: |
           sudo apt-get update
           sudo apt-get -y install qemu-user-static buildah less git make podman clamav clamav-freshclam

--- a/.github/workflows/build_ci_multi.yml
+++ b/.github/workflows/build_ci_multi.yml
@@ -4,6 +4,9 @@ on:
     types: [ opened, synchronize, reopened, labeled, unlabeled ]
     branches:
       - main
+
+permissions: {}
+
 env:
   REGISTRY_USER: ${{ github.actor }}
   REGISTRY_PASSWORD: ${{ github.token }}

--- a/.github/workflows/build_latest_release_multi.yml
+++ b/.github/workflows/build_latest_release_multi.yml
@@ -24,11 +24,12 @@ jobs:
         install_latest: [ true ]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
+          persist-credentials: false
           tag_name: ${{ github.ref }}
       - name: Log in to ghcr.io
-        uses: redhat-actions/podman-login@v1
+        uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1
         with:
           username: ${{ env.REGISTRY_USER }}
           password: ${{ env.REGISTRY_PASSWORD }}
@@ -64,7 +65,7 @@ jobs:
           buildah manifest push --format v2s2 --all curl-base-multi:$REL "docker://ghcr.io/curl/curl-container/curl-base-multi:${REL}"
         name: 'push images to github registry'
       - name: Install Cosign
-        uses: sigstore/cosign-installer@main
+        uses: sigstore/cosign-installer@d7543c93d881b35a8faa02e8e3605f69b7a1ce62 # v3
       - name: Write signing key to disk (only needed for `cosign sign --key`)
         run: echo "${{ secrets.COSIGN_PRIVATE_KEY }}" > cosign.key
       - name: Sign images with sigstore key

--- a/.github/workflows/build_latest_release_multi.yml
+++ b/.github/workflows/build_latest_release_multi.yml
@@ -3,6 +3,9 @@ on:
   push:
     tags:
       - '*'
+
+permissions: {}
+
 env:
   REGISTRY_USER: ${{ github.actor }}
   REGISTRY_PASSWORD: ${{ github.token }}

--- a/.github/workflows/build_master.yml
+++ b/.github/workflows/build_master.yml
@@ -26,11 +26,12 @@ jobs:
         install_latest: [ true ]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
+          persist-credentials: false
           ref: "main"
       - name: Log in to ghcr.io
-        uses: redhat-actions/podman-login@v1
+        uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1
         with:
           username: ${{ env.REGISTRY_USER }}
           password: ${{ env.REGISTRY_PASSWORD }}
@@ -59,7 +60,7 @@ jobs:
           buildah push curl:master "docker://ghcr.io/curl/curl-container/curl:master"
         name: 'push images to github registry'
       - name: Install Cosign
-        uses: sigstore/cosign-installer@main
+        uses: sigstore/cosign-installer@d7543c93d881b35a8faa02e8e3605f69b7a1ce62 # v3
       - name: Write signing key to disk (only needed for `cosign sign --key`)
         run: echo "${{ secrets.COSIGN_PRIVATE_KEY }}" > cosign.key
       - name: Sign image with a key

--- a/.github/workflows/build_master.yml
+++ b/.github/workflows/build_master.yml
@@ -6,6 +6,8 @@ on:
     branches:
     - main
 
+permissions: {}
+
 env:
   REGISTRY_USER: ${{ github.actor }}
   REGISTRY_PASSWORD: ${{ github.token }}

--- a/.github/workflows/build_master_dev.yml
+++ b/.github/workflows/build_master_dev.yml
@@ -27,11 +27,12 @@ jobs:
         install_latest: [ true ]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
+          persist-credentials: false
           ref: "main"
       - name: Log in to ghcr.io
-        uses: redhat-actions/podman-login@v1
+        uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1
         with:
           username: ${{ env.REGISTRY_USER }}
           password: ${{ env.REGISTRY_PASSWORD }}
@@ -56,7 +57,7 @@ jobs:
           buildah push curl-dev-debian:master "docker://ghcr.io/curl/curl-container/curl-dev-debian:master"
         name: 'push images to github registry'
       - name: Install Cosign
-        uses: sigstore/cosign-installer@main
+        uses: sigstore/cosign-installer@d7543c93d881b35a8faa02e8e3605f69b7a1ce62 # v3
       - name: Write signing key to disk (only needed for `cosign sign --key`)
         run: echo "${{ secrets.COSIGN_PRIVATE_KEY }}" > cosign.key
       - name: Sign image with a key
@@ -77,7 +78,7 @@ jobs:
           buildah push curl-dev-fedora:master "docker://ghcr.io/curl/curl-container/curl-dev-fedora:master"
         name: 'push images to github registry'
       - name: Install Cosign
-        uses: sigstore/cosign-installer@main
+        uses: sigstore/cosign-installer@d7543c93d881b35a8faa02e8e3605f69b7a1ce62 # v3
       - name: Write signing key to disk (only needed for `cosign sign --key`)
         run: echo "${{ secrets.COSIGN_PRIVATE_KEY }}" > cosign.key
       - name: Sign image with a key

--- a/.github/workflows/build_master_dev.yml
+++ b/.github/workflows/build_master_dev.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches:
     - main
+
+permissions: {}
+
 env:
   REGISTRY_USER: ${{ github.actor }}
   REGISTRY_PASSWORD: ${{ github.token }}

--- a/.github/workflows/build_master_multi.yml
+++ b/.github/workflows/build_master_multi.yml
@@ -6,6 +6,8 @@ on:
     branches:
     - main
 
+permissions: {}
+
 env:
   REGISTRY_USER: ${{ github.actor }}
   REGISTRY_PASSWORD: ${{ github.token }}

--- a/.github/workflows/build_master_multi.yml
+++ b/.github/workflows/build_master_multi.yml
@@ -26,11 +26,12 @@ jobs:
         install_latest: [ true ]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
+          persist-credentials: false
           ref: "main"
       - name: Log in to ghcr.io
-        uses: redhat-actions/podman-login@v1
+        uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1
         with:
           username: ${{ env.REGISTRY_USER }}
           password: ${{ env.REGISTRY_PASSWORD }}
@@ -58,7 +59,7 @@ jobs:
           buildah manifest push --all --format v2s2 localhost/curl-multi:master "docker://ghcr.io/curl/curl-container/curl-multi:master"
         name: 'push multi images to github registry'
       - name: Install Cosign
-        uses: sigstore/cosign-installer@main
+        uses: sigstore/cosign-installer@d7543c93d881b35a8faa02e8e3605f69b7a1ce62 # v3
       - name: Write signing key to disk (only needed for `cosign sign --key`)
         run: echo "${{ secrets.COSIGN_PRIVATE_KEY }}" > cosign.key
       - name: Sign image with a key

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+<!--
+Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
+-->
+# Security Policy
+
+See curl's
+[SECURITY-PROCESS.md](https://github.com/curl/curl/blob/master/docs/SECURITY-PROCESS.md)
+for full details.
+
+## Reporting a Vulnerability
+
+If you have found or just suspect a security problem somewhere in curl,
+report it on [https://hackerone.com/curl](https://hackerone.com/curl).
+
+We treat security issues with confidentiality until controlled and disclosed responsibly.


### PR DESCRIPTION
---

To bump the pinned actions, we could enable Dependabot.

There is a brand new feature called immutable releases, and
it seems to be enabled for `actions/checkout`, but possibly
only for future releases (aka: not yet) (there needs to be
"🔒 Immutable" text below the title on the release page):
https://github.com/actions/checkout/releases/tag/v5.0.0
https://raw.githubusercontent.com/github/codeql/refs/heads/main/actions/ql/extensions/immutable-actions-list/ext/immutable_actions.yml
https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/immutable-releases