### PR TITLE
drop failing pip package install from the image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -13,8 +13,4 @@ from quay.io/buildah/stable:latest
 
 RUN dnf --nodocs --setopt install_weak_deps=false -y install less git make podman qemu qemu-user-static buildah clamav clamav-freshclam
 
-COPY requirements.txt requirements.txt
-RUN python3 -m ensurepip
-RUN pip3 install --no-input -r requirements.txt
-
 WORKDIR /opt/app-root/src/

--- a/create_dev_image.sh
+++ b/create_dev_image.sh
@@ -88,10 +88,6 @@ fi
 # install curl in /build
 buildah run $bdr make DESTDIR="/build/" install  -j$(nproc)
 
-# install useful dev deps¡
-buildah run $bdr python3 -m ensurepip
-#buildah run $bdr pip3 --no-input install -r ./requirements.txt
-
 # label image
 buildah config --label org.opencontainers.image.source="https://github.com/curl/curl-container" $bdr
 buildah config --label org.opencontainers.image.description="minimal dev image for curl" $bdr

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,0 @@
-pytest
-pytest-cov
-pytest-sugar
-factory-boy
-lxml
-behave


### PR DESCRIPTION
Install seems to be failing:
```
error: externally-managed-environment

× This environment is externally managed
╰─>
    The system-wide python installation should be maintained using the system
    package manager (apk) only.

    If the package in question is not packaged already (and hence installable via
    "apk add py3-somepackage"), please consider installing it inside a virtual
    environment, e.g.:

    python3 -m venv /path/to/venv
    . /path/to/venv/bin/activate
    pip install mypackage

    To exit the virtual environment, run:

    deactivate

    The virtual environment is not deleted, and can be re-entered by re-sourcing
    the activate file.

    To automatically manage virtual environments, consider using pipx (from the
    pipx package).

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/usr/lib/python3.12/ensurepip/__main__.py", line 5, in <module>
    sys.exit(ensurepip._main())
             ^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/ensurepip/__init__.py", line 284, in _main
    return _bootstrap(
           ^^^^^^^^^^^
  File "/usr/lib/python3.12/ensurepip/__init__.py", line 200, in _bootstrap
    return _run_pip([*args, *_PACKAGE_NAMES], additional_paths)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/ensurepip/__init__.py", line 101, in _run_pip
    return subprocess.run(cmd, check=True).returncode
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['/usr/bin/python3', '-W', 'ignore::DeprecationWarning', '-c', '\nimport runpy\nimport sys\nsys.path = [\'/tmp/tmpk9h3ixvs/pip-25.0.1-py3-none-any.whl\'] + sys.path\nsys.argv[1:] = [\'install\', \'--no-cache-dir\', \'--no-index\', \'--find-links\', \'/tmp/tmpk9h3ixvs\', \'pip\']\nrunpy.run_module("pip", run_name="__main__", alter_sys=True)\n']' returned non-zero exit status 1.
Error: while running runtime: exit status 1
```
Ref: https://github.com/curl/curl-container/actions/runs/18084279232/job/51452471235#step:7:6234