### PR TITLE
fix: docker.cmd annotation

### DIFF
--- a/create_appliance_image.sh
+++ b/create_appliance_image.sh
@@ -32,7 +32,7 @@ fi
 buildah config --label maintainer="James Fuller <jim.fuller@webcomposite.com>" $ctr
 buildah config --label name="${image_name}" $ctr
 buildah config --label version="${release_tag}" $ctr
-buildah config --label docker.cmd="podman run -it quay.io/curl/${IMAGE_NAME_DEFAULT}:${release_tag}" $ctr
+buildah config --label docker.cmd="podman run -it quay.io/curl/${image_name}:${release_tag}" $ctr
 
 # assumes base image has setup curl_user
 buildah config --user curl_user $ctr

--- a/create_base_image.sh
+++ b/create_base_image.sh
@@ -42,7 +42,7 @@ ctrmnt=$(buildah mount $ctr)
 buildah config --label maintainer="James Fuller <jim.fuller@webcomposite.com>" $ctr
 buildah config --label name="${image_name}" $ctr
 buildah config --label version="${release_tag}" $ctr
-buildah config --label docker.cmd="podman run -it quay.io/curl/${IMAGE_NAME_DEFAULT}:${release_tag}" $ctr
+buildah config --label docker.cmd="podman run -it quay.io/curl/${image_name}:${release_tag}" $ctr
 
 # determine dist package manager
 if [[ "$dist" =~ .*"alpine".* ]]; then


### PR DESCRIPTION
This PR fixes the `docker.cmd` annotation:

```
➜  nuro labels curlimages/curl                                                                               ( doesn't exist)
+--------------------------------------+--------------------------------------------+
| KEY                                  | VALUE                                      |
+--------------------------------------+--------------------------------------------+
| org.opencontainers.image.licenses    | MIT                                        |
| org.opencontainers.image.source      | https://github.com/curl/curl-container     |
| version                              | 8.16.0                                     |
| docker.cmd                           | podman run -it quay.io/curl/:8.16.0        |
| io.buildah.version                   | 1.33.7                                     |
| maintainer                           | James Fuller <jim.fuller@webcomposite.com> |
| name                                 | curl-linux-386:8.16.0                      |
| org.opencontainers.image.description | minimal image for curl                     |
+--------------------------------------+--------------------------------------------+
```