### PR TITLE
GHA: omit 3rd-party actions, reduce logged-in time, misc improvements

### DIFF
--- a/.github/workflows/build_ci_multi.yml
+++ b/.github/workflows/build_ci_multi.yml
@@ -23,21 +23,21 @@ jobs:
           REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         run: |
           podman --version
-          ls -l "$HOME"/.docker/config.json || true; "${XDG_RUNTIME_DIR}"/containers/auth.json || true
+          ls -l "$HOME"/.docker/config.json || true; ls -l "${XDG_RUNTIME_DIR}"/containers/auth.json || true
           echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
-          ls -l "$HOME"/.docker/config.json || true; "${XDG_RUNTIME_DIR}"/containers/auth.json || true
+          ls -l "$HOME"/.docker/config.json || true; ls -l "${XDG_RUNTIME_DIR}"/containers/auth.json || true
           docker --version
-          ls -l "$HOME"/.docker/config.json || true; "${XDG_RUNTIME_DIR}"/containers/auth.json || true
+          ls -l "$HOME"/.docker/config.json || true; ls -l "${XDG_RUNTIME_DIR}"/containers/auth.json || true
           echo "${REGISTRY_TOKEN}" | docker login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
-          ls -l "$HOME"/.docker/config.json || true; "${XDG_RUNTIME_DIR}"/containers/auth.json || true
+          ls -l "$HOME"/.docker/config.json || true; ls -l "${XDG_RUNTIME_DIR}"/containers/auth.json || true
 
       - name: 'logout (ghcr.io)'
         run: |
-          ls -l "$HOME"/.docker/config.json || true; "${XDG_RUNTIME_DIR}"/containers/auth.json || true
+          ls -l "$HOME"/.docker/config.json || true; ls -l "${XDG_RUNTIME_DIR}"/containers/auth.json || true
           podman logout "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
-          ls -l "$HOME"/.docker/config.json || true; "${XDG_RUNTIME_DIR}"/containers/auth.json || true
+          ls -l "$HOME"/.docker/config.json || true; ls -l "${XDG_RUNTIME_DIR}"/containers/auth.json || true
           docker logout "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
-          ls -l "$HOME"/.docker/config.json || true; "${XDG_RUNTIME_DIR}"/containers/auth.json || true
+          ls -l "$HOME"/.docker/config.json || true; ls -l "${XDG_RUNTIME_DIR}"/containers/auth.json || true
 
       - name: 'login (ghcr.io) as repo owner'
         env:
@@ -51,11 +51,11 @@ jobs:
 
       - name: 'logout (ghcr.io)'
         run: |
-          ls -l "$HOME"/.docker/config.json || true; "${XDG_RUNTIME_DIR}"/containers/auth.json || true
+          ls -l "$HOME"/.docker/config.json || true; ls -l "${XDG_RUNTIME_DIR}"/containers/auth.json || true
           podman logout "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
-          ls -l "$HOME"/.docker/config.json || true; "${XDG_RUNTIME_DIR}"/containers/auth.json || true
+          ls -l "$HOME"/.docker/config.json || true; ls -l "${XDG_RUNTIME_DIR}"/containers/auth.json || true
           docker logout "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
-          ls -l "$HOME"/.docker/config.json || true; "${XDG_RUNTIME_DIR}"/containers/auth.json || true
+          ls -l "$HOME"/.docker/config.json || true; ls -l "${XDG_RUNTIME_DIR}"/containers/auth.json || true
 
   verify_secrets_registries:
     name: 'Verify credentials (docker hub, quay)'
@@ -67,19 +67,19 @@ jobs:
           DOCKER_HUB_USER: '${{ secrets.DOCKER_HUB_USER }}'
           DOCKER_HUB_TOKEN: '${{ secrets.DOCKER_HUB_TOKEN }}'
         run: |
-          ls -l "$HOME"/.docker/config.json || true; "${XDG_RUNTIME_DIR}"/containers/auth.json || true
+          ls -l "$HOME"/.docker/config.json || true; ls -l "${XDG_RUNTIME_DIR}"/containers/auth.json || true
           echo "${DOCKER_HUB_TOKEN}" | podman login -u "${DOCKER_HUB_USER}" --password-stdin docker.io
-          ls -l "$HOME"/.docker/config.json || true; "${XDG_RUNTIME_DIR}"/containers/auth.json || true
+          ls -l "$HOME"/.docker/config.json || true; ls -l "${XDG_RUNTIME_DIR}"/containers/auth.json || true
           echo "${DOCKER_HUB_TOKEN}" | docker login -u "${DOCKER_HUB_USER}" --password-stdin
-          ls -l "$HOME"/.docker/config.json || true; "${XDG_RUNTIME_DIR}"/containers/auth.json || true
+          ls -l "$HOME"/.docker/config.json || true; ls -l "${XDG_RUNTIME_DIR}"/containers/auth.json || true
 
       - name: 'logout (docker.io)'
         run: |
-          ls -l "$HOME"/.docker/config.json || true; "${XDG_RUNTIME_DIR}"/containers/auth.json || true
+          ls -l "$HOME"/.docker/config.json || true; ls -l "${XDG_RUNTIME_DIR}"/containers/auth.json || true
           podman logout docker.io
-          ls -l "$HOME"/.docker/config.json || true; "${XDG_RUNTIME_DIR}"/containers/auth.json || true
+          ls -l "$HOME"/.docker/config.json || true; ls -l "${XDG_RUNTIME_DIR}"/containers/auth.json || true
           docker logout
-          ls -l "$HOME"/.docker/config.json || true; "${XDG_RUNTIME_DIR}"/containers/auth.json || true
+          ls -l "$HOME"/.docker/config.json || true; ls -l "${XDG_RUNTIME_DIR}"/containers/auth.json || true
 
       - name: 'login (quay.io)'
         env:
@@ -91,11 +91,11 @@ jobs:
 
       - name: 'logout (quay.io)'
         run: |
-          ls -l "$HOME"/.docker/config.json || true; "${XDG_RUNTIME_DIR}"/containers/auth.json || true
+          ls -l "$HOME"/.docker/config.json || true; ls -l "${XDG_RUNTIME_DIR}"/containers/auth.json || true
           podman logout quay.io
-          ls -l "$HOME"/.docker/config.json || true; "${XDG_RUNTIME_DIR}"/containers/auth.json || true
+          ls -l "$HOME"/.docker/config.json || true; ls -l "${XDG_RUNTIME_DIR}"/containers/auth.json || true
           docker logout quay.io
-          ls -l "$HOME"/.docker/config.json || true; "${XDG_RUNTIME_DIR}"/containers/auth.json || true
+          ls -l "$HOME"/.docker/config.json || true; ls -l "${XDG_RUNTIME_DIR}"/containers/auth.json || true
 
   build_multi_ci:
     name: 'build_multi_ci'

--- a/.github/workflows/build_ci_multi.yml
+++ b/.github/workflows/build_ci_multi.yml
@@ -78,8 +78,10 @@ jobs:
 
       - name: 'build multi image'
         run: buildah unshare make branch_or_ref=master release_tag=master multibuild
+
       - name: 'test image'
         run: buildah unshare make dist_name=localhost/curl-multi release_tag=master test
+
       - name: 'security scan image'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"

--- a/.github/workflows/build_ci_multi.yml
+++ b/.github/workflows/build_ci_multi.yml
@@ -17,7 +17,17 @@ jobs:
     name: 'Verify credentials'
     runs-on: 'ubuntu-latest'
     steps:
-      - name: 'login ghcr.io'
+      - name: 'login ghcr.io (actor)'
+        env:
+          REGISTRY_USER: '${{ github.actor }}'
+          REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+        run: |
+          podman --version
+          echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
+          docker --version
+          echo "${REGISTRY_TOKEN}" | docker login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
+
+      - name: 'login ghcr.io (repo owner)'
         env:
           REGISTRY_USER: '${{ github.repository_owner }}'
           REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/build_ci_multi.yml
+++ b/.github/workflows/build_ci_multi.yml
@@ -27,6 +27,11 @@ jobs:
           docker --version
           echo "${REGISTRY_TOKEN}" | docker login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
 
+      - name: 'logout (ghcr.io)'
+        run: |
+          podman logout "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
+          docker logout "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
+
       - name: 'login (ghcr.io) as repo owner'
         env:
           REGISTRY_USER: '${{ github.repository_owner }}'

--- a/.github/workflows/build_ci_multi.yml
+++ b/.github/workflows/build_ci_multi.yml
@@ -23,21 +23,14 @@ jobs:
           REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         run: |
           podman --version
-          ls -l "$HOME"/.docker/config.json || true; ls -l "${XDG_RUNTIME_DIR}"/containers/auth.json || true
           echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
-          ls -l "$HOME"/.docker/config.json || true; ls -l "${XDG_RUNTIME_DIR}"/containers/auth.json || true
           docker --version
-          ls -l "$HOME"/.docker/config.json || true; ls -l "${XDG_RUNTIME_DIR}"/containers/auth.json || true
           echo "${REGISTRY_TOKEN}" | docker login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
-          ls -l "$HOME"/.docker/config.json || true; ls -l "${XDG_RUNTIME_DIR}"/containers/auth.json || true
 
       - name: 'logout (ghcr.io)'
         run: |
-          ls -l "$HOME"/.docker/config.json || true; ls -l "${XDG_RUNTIME_DIR}"/containers/auth.json || true
           podman logout "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
-          ls -l "$HOME"/.docker/config.json || true; ls -l "${XDG_RUNTIME_DIR}"/containers/auth.json || true
           docker logout "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
-          ls -l "$HOME"/.docker/config.json || true; ls -l "${XDG_RUNTIME_DIR}"/containers/auth.json || true
 
       - name: 'login (ghcr.io) as repo owner'
         env:
@@ -51,11 +44,8 @@ jobs:
 
       - name: 'logout (ghcr.io)'
         run: |
-          ls -l "$HOME"/.docker/config.json || true; ls -l "${XDG_RUNTIME_DIR}"/containers/auth.json || true
           podman logout "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
-          ls -l "$HOME"/.docker/config.json || true; ls -l "${XDG_RUNTIME_DIR}"/containers/auth.json || true
           docker logout "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
-          ls -l "$HOME"/.docker/config.json || true; ls -l "${XDG_RUNTIME_DIR}"/containers/auth.json || true
 
   verify_secrets_registries:
     name: 'Verify credentials (docker hub, quay)'
@@ -67,19 +57,13 @@ jobs:
           DOCKER_HUB_USER: '${{ secrets.DOCKER_HUB_USER }}'
           DOCKER_HUB_TOKEN: '${{ secrets.DOCKER_HUB_TOKEN }}'
         run: |
-          ls -l "$HOME"/.docker/config.json || true; ls -l "${XDG_RUNTIME_DIR}"/containers/auth.json || true
           echo "${DOCKER_HUB_TOKEN}" | podman login -u "${DOCKER_HUB_USER}" --password-stdin docker.io
-          ls -l "$HOME"/.docker/config.json || true; ls -l "${XDG_RUNTIME_DIR}"/containers/auth.json || true
           echo "${DOCKER_HUB_TOKEN}" | docker login -u "${DOCKER_HUB_USER}" --password-stdin
-          ls -l "$HOME"/.docker/config.json || true; ls -l "${XDG_RUNTIME_DIR}"/containers/auth.json || true
 
       - name: 'logout (docker.io)'
         run: |
-          ls -l "$HOME"/.docker/config.json || true; ls -l "${XDG_RUNTIME_DIR}"/containers/auth.json || true
           podman logout docker.io
-          ls -l "$HOME"/.docker/config.json || true; ls -l "${XDG_RUNTIME_DIR}"/containers/auth.json || true
           docker logout
-          ls -l "$HOME"/.docker/config.json || true; ls -l "${XDG_RUNTIME_DIR}"/containers/auth.json || true
 
       - name: 'login (quay.io)'
         env:
@@ -91,11 +75,8 @@ jobs:
 
       - name: 'logout (quay.io)'
         run: |
-          ls -l "$HOME"/.docker/config.json || true; ls -l "${XDG_RUNTIME_DIR}"/containers/auth.json || true
           podman logout quay.io
-          ls -l "$HOME"/.docker/config.json || true; ls -l "${XDG_RUNTIME_DIR}"/containers/auth.json || true
           docker logout quay.io
-          ls -l "$HOME"/.docker/config.json || true; ls -l "${XDG_RUNTIME_DIR}"/containers/auth.json || true
 
   build_multi_ci:
     name: 'build_multi_ci'

--- a/.github/workflows/build_ci_multi.yml
+++ b/.github/workflows/build_ci_multi.yml
@@ -23,21 +23,21 @@ jobs:
           REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         run: |
           podman --version
-          ls -l "$HOME"/.docker/config.json || true; "$HOME"/.config/containers/auth.json || true
+          ls -l "$HOME"/.docker/config.json || true; "${XDG_RUNTIME_DIR}"/containers/auth.json || true
           echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
-          ls -l "$HOME"/.docker/config.json || true; "$HOME"/.config/containers/auth.json || true
+          ls -l "$HOME"/.docker/config.json || true; "${XDG_RUNTIME_DIR}"/containers/auth.json || true
           docker --version
-          ls -l "$HOME"/.docker/config.json || true; "$HOME"/.config/containers/auth.json || true
+          ls -l "$HOME"/.docker/config.json || true; "${XDG_RUNTIME_DIR}"/containers/auth.json || true
           echo "${REGISTRY_TOKEN}" | docker login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
-          ls -l "$HOME"/.docker/config.json || true; "$HOME"/.config/containers/auth.json || true
+          ls -l "$HOME"/.docker/config.json || true; "${XDG_RUNTIME_DIR}"/containers/auth.json || true
 
       - name: 'logout (ghcr.io)'
         run: |
-          ls -l "$HOME"/.docker/config.json || true; "$HOME"/.config/containers/auth.json || true
+          ls -l "$HOME"/.docker/config.json || true; "${XDG_RUNTIME_DIR}"/containers/auth.json || true
           podman logout "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
-          ls -l "$HOME"/.docker/config.json || true; "$HOME"/.config/containers/auth.json || true
+          ls -l "$HOME"/.docker/config.json || true; "${XDG_RUNTIME_DIR}"/containers/auth.json || true
           docker logout "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
-          ls -l "$HOME"/.docker/config.json || true; "$HOME"/.config/containers/auth.json || true
+          ls -l "$HOME"/.docker/config.json || true; "${XDG_RUNTIME_DIR}"/containers/auth.json || true
 
       - name: 'login (ghcr.io) as repo owner'
         env:
@@ -51,11 +51,11 @@ jobs:
 
       - name: 'logout (ghcr.io)'
         run: |
-          ls -l "$HOME"/.docker/config.json || true; "$HOME"/.config/containers/auth.json || true
+          ls -l "$HOME"/.docker/config.json || true; "${XDG_RUNTIME_DIR}"/containers/auth.json || true
           podman logout "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
-          ls -l "$HOME"/.docker/config.json || true; "$HOME"/.config/containers/auth.json || true
+          ls -l "$HOME"/.docker/config.json || true; "${XDG_RUNTIME_DIR}"/containers/auth.json || true
           docker logout "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
-          ls -l "$HOME"/.docker/config.json || true; "$HOME"/.config/containers/auth.json || true
+          ls -l "$HOME"/.docker/config.json || true; "${XDG_RUNTIME_DIR}"/containers/auth.json || true
 
   verify_secrets_registries:
     name: 'Verify credentials (docker hub, quay)'
@@ -67,19 +67,19 @@ jobs:
           DOCKER_HUB_USER: '${{ secrets.DOCKER_HUB_USER }}'
           DOCKER_HUB_TOKEN: '${{ secrets.DOCKER_HUB_TOKEN }}'
         run: |
-          ls -l "$HOME"/.docker/config.json || true; "$HOME"/.config/containers/auth.json || true
+          ls -l "$HOME"/.docker/config.json || true; "${XDG_RUNTIME_DIR}"/containers/auth.json || true
           echo "${DOCKER_HUB_TOKEN}" | podman login -u "${DOCKER_HUB_USER}" --password-stdin docker.io
-          ls -l "$HOME"/.docker/config.json || true; "$HOME"/.config/containers/auth.json || true
+          ls -l "$HOME"/.docker/config.json || true; "${XDG_RUNTIME_DIR}"/containers/auth.json || true
           echo "${DOCKER_HUB_TOKEN}" | docker login -u "${DOCKER_HUB_USER}" --password-stdin
-          ls -l "$HOME"/.docker/config.json || true; "$HOME"/.config/containers/auth.json || true
+          ls -l "$HOME"/.docker/config.json || true; "${XDG_RUNTIME_DIR}"/containers/auth.json || true
 
       - name: 'logout (docker.io)'
         run: |
-          ls -l "$HOME"/.docker/config.json || true; "$HOME"/.config/containers/auth.json || true
+          ls -l "$HOME"/.docker/config.json || true; "${XDG_RUNTIME_DIR}"/containers/auth.json || true
           podman logout docker.io
-          ls -l "$HOME"/.docker/config.json || true; "$HOME"/.config/containers/auth.json || true
+          ls -l "$HOME"/.docker/config.json || true; "${XDG_RUNTIME_DIR}"/containers/auth.json || true
           docker logout
-          ls -l "$HOME"/.docker/config.json || true; "$HOME"/.config/containers/auth.json || true
+          ls -l "$HOME"/.docker/config.json || true; "${XDG_RUNTIME_DIR}"/containers/auth.json || true
 
       - name: 'login (quay.io)'
         env:
@@ -91,11 +91,11 @@ jobs:
 
       - name: 'logout (quay.io)'
         run: |
-          ls -l "$HOME"/.docker/config.json || true; "$HOME"/.config/containers/auth.json || true
+          ls -l "$HOME"/.docker/config.json || true; "${XDG_RUNTIME_DIR}"/containers/auth.json || true
           podman logout quay.io
-          ls -l "$HOME"/.docker/config.json || true; "$HOME"/.config/containers/auth.json || true
+          ls -l "$HOME"/.docker/config.json || true; "${XDG_RUNTIME_DIR}"/containers/auth.json || true
           docker logout quay.io
-          ls -l "$HOME"/.docker/config.json || true; "$HOME"/.config/containers/auth.json || true
+          ls -l "$HOME"/.docker/config.json || true; "${XDG_RUNTIME_DIR}"/containers/auth.json || true
 
   build_multi_ci:
     name: 'build_multi_ci'

--- a/.github/workflows/build_ci_multi.yml
+++ b/.github/workflows/build_ci_multi.yml
@@ -17,16 +17,7 @@ jobs:
     name: 'Verify credentials'
     runs-on: 'ubuntu-latest'
     steps:
-      # upside: it logs out and aims to delete creds ~/.docker/config.json
-      # downside: extra dependency, uses -p instead of --password-stdin
-      - name: 'login ghcr.io (actor, via action)'
-        uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7
-        with:
-          username: '${{ github.actor }}'
-          password: '${{ secrets.GITHUB_TOKEN }}'
-          registry: 'ghcr.io/${{ github.repository_owner }}'
-
-      - name: 'login ghcr.io (actor, direct)'
+      - name: 'login ghcr.io (actor)'
         env:
           REGISTRY_USER: '${{ github.actor }}'
           REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
@@ -36,7 +27,7 @@ jobs:
           docker --version
           echo "${REGISTRY_TOKEN}" | docker login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
 
-      - name: 'login ghcr.io (repo owner, direct)'
+      - name: 'login ghcr.io (repo owner)'
         env:
           REGISTRY_USER: '${{ github.repository_owner }}'
           REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/build_ci_multi.yml
+++ b/.github/workflows/build_ci_multi.yml
@@ -23,21 +23,21 @@ jobs:
           REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         run: |
           podman --version
-          ls -l "$HOME"/.docker/config.json
+          ls -l "$HOME"/.docker/config.json $HOME/.config/containers/auth.json
           echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
-          ls -l "$HOME"/.docker/config.json
+          ls -l "$HOME"/.docker/config.json $HOME/.config/containers/auth.json
           docker --version
-          ls -l "$HOME"/.docker/config.json
+          ls -l "$HOME"/.docker/config.json $HOME/.config/containers/auth.json
           echo "${REGISTRY_TOKEN}" | docker login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
-          ls -l "$HOME"/.docker/config.json
+          ls -l "$HOME"/.docker/config.json $HOME/.config/containers/auth.json
 
       - name: 'logout (ghcr.io)'
         run: |
-          ls -l "$HOME"/.docker/config.json
+          ls -l "$HOME"/.docker/config.json $HOME/.config/containers/auth.json
           podman logout "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
-          ls -l "$HOME"/.docker/config.json
+          ls -l "$HOME"/.docker/config.json $HOME/.config/containers/auth.json
           docker logout "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
-          ls -l "$HOME"/.docker/config.json
+          ls -l "$HOME"/.docker/config.json $HOME/.config/containers/auth.json
 
       - name: 'login (ghcr.io) as repo owner'
         env:
@@ -51,11 +51,11 @@ jobs:
 
       - name: 'logout (ghcr.io)'
         run: |
-          ls -l "$HOME"/.docker/config.json
+          ls -l "$HOME"/.docker/config.json $HOME/.config/containers/auth.json
           podman logout "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
-          ls -l "$HOME"/.docker/config.json
+          ls -l "$HOME"/.docker/config.json $HOME/.config/containers/auth.json
           docker logout "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
-          ls -l "$HOME"/.docker/config.json
+          ls -l "$HOME"/.docker/config.json $HOME/.config/containers/auth.json
 
   verify_secrets_registries:
     name: 'Verify credentials (docker hub, quay)'
@@ -67,19 +67,19 @@ jobs:
           DOCKER_HUB_USER: '${{ secrets.DOCKER_HUB_USER }}'
           DOCKER_HUB_TOKEN: '${{ secrets.DOCKER_HUB_TOKEN }}'
         run: |
-          ls -l "$HOME"/.docker/config.json
+          ls -l "$HOME"/.docker/config.json $HOME/.config/containers/auth.json
           echo "${DOCKER_HUB_TOKEN}" | podman login -u "${DOCKER_HUB_USER}" --password-stdin docker.io
-          ls -l "$HOME"/.docker/config.json
+          ls -l "$HOME"/.docker/config.json $HOME/.config/containers/auth.json
           echo "${DOCKER_HUB_TOKEN}" | docker login -u "${DOCKER_HUB_USER}" --password-stdin
-          ls -l "$HOME"/.docker/config.json
+          ls -l "$HOME"/.docker/config.json $HOME/.config/containers/auth.json
 
       - name: 'logout (docker.io)'
         run: |
-          ls -l "$HOME"/.docker/config.json
+          ls -l "$HOME"/.docker/config.json $HOME/.config/containers/auth.json
           podman logout docker.io
-          ls -l "$HOME"/.docker/config.json
+          ls -l "$HOME"/.docker/config.json $HOME/.config/containers/auth.json
           docker logout
-          ls -l "$HOME"/.docker/config.json
+          ls -l "$HOME"/.docker/config.json $HOME/.config/containers/auth.json
 
       - name: 'login (quay.io)'
         env:
@@ -91,11 +91,11 @@ jobs:
 
       - name: 'logout (quay.io)'
         run: |
-          ls -l "$HOME"/.docker/config.json
+          ls -l "$HOME"/.docker/config.json $HOME/.config/containers/auth.json
           podman logout quay.io
-          ls -l "$HOME"/.docker/config.json
+          ls -l "$HOME"/.docker/config.json $HOME/.config/containers/auth.json
           docker logout quay.io
-          ls -l "$HOME"/.docker/config.json
+          ls -l "$HOME"/.docker/config.json $HOME/.config/containers/auth.json
 
   build_multi_ci:
     name: 'build_multi_ci'

--- a/.github/workflows/build_ci_multi.yml
+++ b/.github/workflows/build_ci_multi.yml
@@ -92,7 +92,9 @@ jobs:
         run: /home/linuxbrew/.linuxbrew/bin/brew install cosign grype trivy
 
       - name: 'versions'
-        run: podman --version; docker --version; cosign version
+        run: |
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+          podman --version; docker --version; cosign version
 
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:

--- a/.github/workflows/build_ci_multi.yml
+++ b/.github/workflows/build_ci_multi.yml
@@ -17,14 +17,15 @@ jobs:
     name: 'Verify credentials'
     runs-on: 'ubuntu-latest'
     steps:
+      - name: 'versions'
+        run: podman --version; docker --version
+
       - name: 'login (ghcr.io) as actor'
         env:
           REGISTRY_USER: '${{ github.actor }}'
           REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         run: |
-          podman --version
           echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin ghcr.io/"${GITHUB_REPOSITORY_OWNER}"
-          docker --version
           echo "${REGISTRY_TOKEN}" | docker login -u "${REGISTRY_USER}" --password-stdin ghcr.io/"${GITHUB_REPOSITORY_OWNER}"
 
       - name: 'logout (ghcr.io)'
@@ -37,9 +38,7 @@ jobs:
           REGISTRY_USER: '${{ github.repository_owner }}'
           REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         run: |
-          podman --version
           echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin ghcr.io/"${GITHUB_REPOSITORY_OWNER}"
-          docker --version
           echo "${REGISTRY_TOKEN}" | docker login -u "${REGISTRY_USER}" --password-stdin ghcr.io/"${GITHUB_REPOSITORY_OWNER}"
 
       - name: 'logout (ghcr.io)'
@@ -91,6 +90,9 @@ jobs:
 
       - name: 'install prereqs'
         run: /home/linuxbrew/.linuxbrew/bin/brew install cosign grype trivy
+
+      - name: 'versions'
+        run: podman --version; docker --version; cosign version
 
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:

--- a/.github/workflows/build_ci_multi.yml
+++ b/.github/workflows/build_ci_multi.yml
@@ -23,21 +23,21 @@ jobs:
           REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         run: |
           podman --version
-          ls -l "$HOME"/.docker/config.json; "$HOME"/.config/containers/auth.json
+          ls -l "$HOME"/.docker/config.json || true; "$HOME"/.config/containers/auth.json || true
           echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
-          ls -l "$HOME"/.docker/config.json; "$HOME"/.config/containers/auth.json
+          ls -l "$HOME"/.docker/config.json || true; "$HOME"/.config/containers/auth.json || true
           docker --version
-          ls -l "$HOME"/.docker/config.json; "$HOME"/.config/containers/auth.json
+          ls -l "$HOME"/.docker/config.json || true; "$HOME"/.config/containers/auth.json || true
           echo "${REGISTRY_TOKEN}" | docker login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
-          ls -l "$HOME"/.docker/config.json; "$HOME"/.config/containers/auth.json
+          ls -l "$HOME"/.docker/config.json || true; "$HOME"/.config/containers/auth.json || true
 
       - name: 'logout (ghcr.io)'
         run: |
-          ls -l "$HOME"/.docker/config.json; "$HOME"/.config/containers/auth.json
+          ls -l "$HOME"/.docker/config.json || true; "$HOME"/.config/containers/auth.json || true
           podman logout "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
-          ls -l "$HOME"/.docker/config.json; "$HOME"/.config/containers/auth.json
+          ls -l "$HOME"/.docker/config.json || true; "$HOME"/.config/containers/auth.json || true
           docker logout "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
-          ls -l "$HOME"/.docker/config.json; "$HOME"/.config/containers/auth.json
+          ls -l "$HOME"/.docker/config.json || true; "$HOME"/.config/containers/auth.json || true
 
       - name: 'login (ghcr.io) as repo owner'
         env:
@@ -51,11 +51,11 @@ jobs:
 
       - name: 'logout (ghcr.io)'
         run: |
-          ls -l "$HOME"/.docker/config.json; "$HOME"/.config/containers/auth.json
+          ls -l "$HOME"/.docker/config.json || true; "$HOME"/.config/containers/auth.json || true
           podman logout "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
-          ls -l "$HOME"/.docker/config.json; "$HOME"/.config/containers/auth.json
+          ls -l "$HOME"/.docker/config.json || true; "$HOME"/.config/containers/auth.json || true
           docker logout "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
-          ls -l "$HOME"/.docker/config.json; "$HOME"/.config/containers/auth.json
+          ls -l "$HOME"/.docker/config.json || true; "$HOME"/.config/containers/auth.json || true
 
   verify_secrets_registries:
     name: 'Verify credentials (docker hub, quay)'
@@ -67,19 +67,19 @@ jobs:
           DOCKER_HUB_USER: '${{ secrets.DOCKER_HUB_USER }}'
           DOCKER_HUB_TOKEN: '${{ secrets.DOCKER_HUB_TOKEN }}'
         run: |
-          ls -l "$HOME"/.docker/config.json; "$HOME"/.config/containers/auth.json
+          ls -l "$HOME"/.docker/config.json || true; "$HOME"/.config/containers/auth.json || true
           echo "${DOCKER_HUB_TOKEN}" | podman login -u "${DOCKER_HUB_USER}" --password-stdin docker.io
-          ls -l "$HOME"/.docker/config.json; "$HOME"/.config/containers/auth.json
+          ls -l "$HOME"/.docker/config.json || true; "$HOME"/.config/containers/auth.json || true
           echo "${DOCKER_HUB_TOKEN}" | docker login -u "${DOCKER_HUB_USER}" --password-stdin
-          ls -l "$HOME"/.docker/config.json; "$HOME"/.config/containers/auth.json
+          ls -l "$HOME"/.docker/config.json || true; "$HOME"/.config/containers/auth.json || true
 
       - name: 'logout (docker.io)'
         run: |
-          ls -l "$HOME"/.docker/config.json; "$HOME"/.config/containers/auth.json
+          ls -l "$HOME"/.docker/config.json || true; "$HOME"/.config/containers/auth.json || true
           podman logout docker.io
-          ls -l "$HOME"/.docker/config.json; "$HOME"/.config/containers/auth.json
+          ls -l "$HOME"/.docker/config.json || true; "$HOME"/.config/containers/auth.json || true
           docker logout
-          ls -l "$HOME"/.docker/config.json; "$HOME"/.config/containers/auth.json
+          ls -l "$HOME"/.docker/config.json || true; "$HOME"/.config/containers/auth.json || true
 
       - name: 'login (quay.io)'
         env:
@@ -91,11 +91,11 @@ jobs:
 
       - name: 'logout (quay.io)'
         run: |
-          ls -l "$HOME"/.docker/config.json; "$HOME"/.config/containers/auth.json
+          ls -l "$HOME"/.docker/config.json || true; "$HOME"/.config/containers/auth.json || true
           podman logout quay.io
-          ls -l "$HOME"/.docker/config.json; "$HOME"/.config/containers/auth.json
+          ls -l "$HOME"/.docker/config.json || true; "$HOME"/.config/containers/auth.json || true
           docker logout quay.io
-          ls -l "$HOME"/.docker/config.json; "$HOME"/.config/containers/auth.json
+          ls -l "$HOME"/.docker/config.json || true; "$HOME"/.config/containers/auth.json || true
 
   build_multi_ci:
     name: 'build_multi_ci'

--- a/.github/workflows/build_ci_multi.yml
+++ b/.github/workflows/build_ci_multi.yml
@@ -23,14 +23,14 @@ jobs:
           REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         run: |
           podman --version
-          echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
+          echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin ghcr.io/"${GITHUB_REPOSITORY_OWNER}"
           docker --version
-          echo "${REGISTRY_TOKEN}" | docker login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
+          echo "${REGISTRY_TOKEN}" | docker login -u "${REGISTRY_USER}" --password-stdin ghcr.io/"${GITHUB_REPOSITORY_OWNER}"
 
       - name: 'logout (ghcr.io)'
         run: |
-          podman logout "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
-          docker logout "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
+          podman logout ghcr.io/"${GITHUB_REPOSITORY_OWNER}"
+          docker logout ghcr.io/"${GITHUB_REPOSITORY_OWNER}"
 
       - name: 'login (ghcr.io) as repo owner'
         env:
@@ -38,14 +38,14 @@ jobs:
           REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         run: |
           podman --version
-          echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
+          echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin ghcr.io/"${GITHUB_REPOSITORY_OWNER}"
           docker --version
-          echo "${REGISTRY_TOKEN}" | docker login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
+          echo "${REGISTRY_TOKEN}" | docker login -u "${REGISTRY_USER}" --password-stdin ghcr.io/"${GITHUB_REPOSITORY_OWNER}"
 
       - name: 'logout (ghcr.io)'
         run: |
-          podman logout "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
-          docker logout "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
+          podman logout ghcr.io/"${GITHUB_REPOSITORY_OWNER}"
+          docker logout ghcr.io/"${GITHUB_REPOSITORY_OWNER}"
 
   verify_secrets_registries:
     name: 'Verify credentials (docker hub, quay)'

--- a/.github/workflows/build_ci_multi.yml
+++ b/.github/workflows/build_ci_multi.yml
@@ -31,12 +31,11 @@ jobs:
         env:
           REGISTRY_USER: '${{ github.repository_owner }}'
           REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-          IMAGE_REGISTRY: 'ghcr.io/${{ github.repository_owner }}'
         run: |
           podman --version
-          echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "${IMAGE_REGISTRY}"
+          echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
           docker --version
-          echo "${REGISTRY_TOKEN}" | docker login -u "${REGISTRY_USER}" --password-stdin "${IMAGE_REGISTRY}"
+          echo "${REGISTRY_TOKEN}" | docker login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
 
   verify_secrets_registries:
     name: 'Verify credentials (docker hub, quay)'

--- a/.github/workflows/build_ci_multi.yml
+++ b/.github/workflows/build_ci_multi.yml
@@ -17,7 +17,7 @@ jobs:
     name: 'Verify credentials'
     runs-on: 'ubuntu-latest'
     steps:
-      - name: 'login ghcr.io (actor)'
+      - name: 'login (ghcr.io) as actor'
         env:
           REGISTRY_USER: '${{ github.actor }}'
           REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
@@ -27,7 +27,7 @@ jobs:
           docker --version
           echo "${REGISTRY_TOKEN}" | docker login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
 
-      - name: 'login ghcr.io (repo owner)'
+      - name: 'login (ghcr.io) as repo owner'
         env:
           REGISTRY_USER: '${{ github.repository_owner }}'
           REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
@@ -42,7 +42,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     if: ${{ github.secret_source == 'Actions' }}
     steps:
-      - name: 'login docker hub'
+      - name: 'login (docker.io)'
         env:
           DOCKER_HUB_USER: '${{ secrets.DOCKER_HUB_USER }}'
           DOCKER_HUB_TOKEN: '${{ secrets.DOCKER_HUB_TOKEN }}'
@@ -50,7 +50,7 @@ jobs:
           echo "${DOCKER_HUB_TOKEN}" | podman login -u "${DOCKER_HUB_USER}" --password-stdin docker.io
           echo "${DOCKER_HUB_TOKEN}" | docker login -u "${DOCKER_HUB_USER}" --password-stdin
 
-      - name: 'login quay.io'
+      - name: 'login (quay.io)'
         env:
           QUAY_USER: '${{ secrets.QUAY_USER }}'
           QUAY_TOKEN: '${{ secrets.QUAY_TOKEN }}'

--- a/.github/workflows/build_ci_multi.yml
+++ b/.github/workflows/build_ci_multi.yml
@@ -37,6 +37,11 @@ jobs:
           docker --version
           echo "${REGISTRY_TOKEN}" | docker login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
 
+      - name: 'logout (ghcr.io)'
+        run: |
+          podman logout "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
+          docker logout "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
+
   verify_secrets_registries:
     name: 'Verify credentials (docker hub, quay)'
     runs-on: 'ubuntu-latest'
@@ -50,6 +55,11 @@ jobs:
           echo "${DOCKER_HUB_TOKEN}" | podman login -u "${DOCKER_HUB_USER}" --password-stdin docker.io
           echo "${DOCKER_HUB_TOKEN}" | docker login -u "${DOCKER_HUB_USER}" --password-stdin
 
+      - name: 'logout (docker.io)'
+        run: |
+          podman logout docker.io
+          docker logout
+
       - name: 'login (quay.io)'
         env:
           QUAY_USER: '${{ secrets.QUAY_USER }}'
@@ -57,6 +67,11 @@ jobs:
         run: |
           echo "${QUAY_TOKEN}" | podman login -u "${QUAY_USER}" --password-stdin quay.io
           echo "${QUAY_TOKEN}" | docker login -u "${QUAY_USER}" --password-stdin quay.io
+
+      - name: 'logout (quay.io)'
+        run: |
+          podman logout quay.io
+          docker logout quay.io
 
   build_multi_ci:
     name: 'build_multi_ci'

--- a/.github/workflows/build_ci_multi.yml
+++ b/.github/workflows/build_ci_multi.yml
@@ -23,21 +23,21 @@ jobs:
           REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         run: |
           podman --version
-          ls -l "$HOME"/.docker/config.json $HOME/.config/containers/auth.json
+          ls -l "$HOME"/.docker/config.json; "$HOME"/.config/containers/auth.json
           echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
-          ls -l "$HOME"/.docker/config.json $HOME/.config/containers/auth.json
+          ls -l "$HOME"/.docker/config.json; "$HOME"/.config/containers/auth.json
           docker --version
-          ls -l "$HOME"/.docker/config.json $HOME/.config/containers/auth.json
+          ls -l "$HOME"/.docker/config.json; "$HOME"/.config/containers/auth.json
           echo "${REGISTRY_TOKEN}" | docker login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
-          ls -l "$HOME"/.docker/config.json $HOME/.config/containers/auth.json
+          ls -l "$HOME"/.docker/config.json; "$HOME"/.config/containers/auth.json
 
       - name: 'logout (ghcr.io)'
         run: |
-          ls -l "$HOME"/.docker/config.json $HOME/.config/containers/auth.json
+          ls -l "$HOME"/.docker/config.json; "$HOME"/.config/containers/auth.json
           podman logout "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
-          ls -l "$HOME"/.docker/config.json $HOME/.config/containers/auth.json
+          ls -l "$HOME"/.docker/config.json; "$HOME"/.config/containers/auth.json
           docker logout "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
-          ls -l "$HOME"/.docker/config.json $HOME/.config/containers/auth.json
+          ls -l "$HOME"/.docker/config.json; "$HOME"/.config/containers/auth.json
 
       - name: 'login (ghcr.io) as repo owner'
         env:
@@ -51,11 +51,11 @@ jobs:
 
       - name: 'logout (ghcr.io)'
         run: |
-          ls -l "$HOME"/.docker/config.json $HOME/.config/containers/auth.json
+          ls -l "$HOME"/.docker/config.json; "$HOME"/.config/containers/auth.json
           podman logout "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
-          ls -l "$HOME"/.docker/config.json $HOME/.config/containers/auth.json
+          ls -l "$HOME"/.docker/config.json; "$HOME"/.config/containers/auth.json
           docker logout "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
-          ls -l "$HOME"/.docker/config.json $HOME/.config/containers/auth.json
+          ls -l "$HOME"/.docker/config.json; "$HOME"/.config/containers/auth.json
 
   verify_secrets_registries:
     name: 'Verify credentials (docker hub, quay)'
@@ -67,19 +67,19 @@ jobs:
           DOCKER_HUB_USER: '${{ secrets.DOCKER_HUB_USER }}'
           DOCKER_HUB_TOKEN: '${{ secrets.DOCKER_HUB_TOKEN }}'
         run: |
-          ls -l "$HOME"/.docker/config.json $HOME/.config/containers/auth.json
+          ls -l "$HOME"/.docker/config.json; "$HOME"/.config/containers/auth.json
           echo "${DOCKER_HUB_TOKEN}" | podman login -u "${DOCKER_HUB_USER}" --password-stdin docker.io
-          ls -l "$HOME"/.docker/config.json $HOME/.config/containers/auth.json
+          ls -l "$HOME"/.docker/config.json; "$HOME"/.config/containers/auth.json
           echo "${DOCKER_HUB_TOKEN}" | docker login -u "${DOCKER_HUB_USER}" --password-stdin
-          ls -l "$HOME"/.docker/config.json $HOME/.config/containers/auth.json
+          ls -l "$HOME"/.docker/config.json; "$HOME"/.config/containers/auth.json
 
       - name: 'logout (docker.io)'
         run: |
-          ls -l "$HOME"/.docker/config.json $HOME/.config/containers/auth.json
+          ls -l "$HOME"/.docker/config.json; "$HOME"/.config/containers/auth.json
           podman logout docker.io
-          ls -l "$HOME"/.docker/config.json $HOME/.config/containers/auth.json
+          ls -l "$HOME"/.docker/config.json; "$HOME"/.config/containers/auth.json
           docker logout
-          ls -l "$HOME"/.docker/config.json $HOME/.config/containers/auth.json
+          ls -l "$HOME"/.docker/config.json; "$HOME"/.config/containers/auth.json
 
       - name: 'login (quay.io)'
         env:
@@ -91,11 +91,11 @@ jobs:
 
       - name: 'logout (quay.io)'
         run: |
-          ls -l "$HOME"/.docker/config.json $HOME/.config/containers/auth.json
+          ls -l "$HOME"/.docker/config.json; "$HOME"/.config/containers/auth.json
           podman logout quay.io
-          ls -l "$HOME"/.docker/config.json $HOME/.config/containers/auth.json
+          ls -l "$HOME"/.docker/config.json; "$HOME"/.config/containers/auth.json
           docker logout quay.io
-          ls -l "$HOME"/.docker/config.json $HOME/.config/containers/auth.json
+          ls -l "$HOME"/.docker/config.json; "$HOME"/.config/containers/auth.json
 
   build_multi_ci:
     name: 'build_multi_ci'

--- a/.github/workflows/build_ci_multi.yml
+++ b/.github/workflows/build_ci_multi.yml
@@ -17,17 +17,7 @@ jobs:
     name: 'Verify credentials'
     runs-on: 'ubuntu-latest'
     steps:
-      - name: 'login ghcr.io (actor)'
-        env:
-          REGISTRY_USER: '${{ github.actor }}'
-          REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-        run: |
-          podman --version
-          echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
-          docker --version
-          echo "${REGISTRY_TOKEN}" | docker login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
-
-      - name: 'login ghcr.io (repo owner)'
+      - name: 'login ghcr.io'
         env:
           REGISTRY_USER: '${{ github.repository_owner }}'
           REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/build_ci_multi.yml
+++ b/.github/workflows/build_ci_multi.yml
@@ -76,8 +76,8 @@ jobs:
         run: buildah unshare make branch_or_ref=master release_tag=master multibuild
       - name: 'test image'
         run: buildah unshare make dist_name=localhost/curl-multi release_tag=master test
-      - name: 'install scan prereqs'
-        run: /home/linuxbrew/.linuxbrew/bin/brew install grype trivy
+      - name: 'install prereqs'
+        run: /home/linuxbrew/.linuxbrew/bin/brew install cosign grype trivy
       - name: 'security scan image'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"

--- a/.github/workflows/build_ci_multi.yml
+++ b/.github/workflows/build_ci_multi.yml
@@ -59,15 +59,17 @@ jobs:
           sudo apt-get -o Dpkg::Use-Pty=0 install \
             qemu-user-static buildah less git make podman clamav clamav-freshclam
 
+      - name: 'install prereqs'
+        run: /home/linuxbrew/.linuxbrew/bin/brew install cosign grype trivy
+
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           persist-credentials: false
+
       - name: 'build multi image'
         run: buildah unshare make branch_or_ref=master release_tag=master multibuild
       - name: 'test image'
         run: buildah unshare make dist_name=localhost/curl-multi release_tag=master test
-      - name: 'install prereqs'
-        run: /home/linuxbrew/.linuxbrew/bin/brew install cosign grype trivy
       - name: 'security scan image'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"

--- a/.github/workflows/build_ci_multi.yml
+++ b/.github/workflows/build_ci_multi.yml
@@ -23,14 +23,21 @@ jobs:
           REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         run: |
           podman --version
+          ls -l "$HOME"/.docker/config.json
           echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
+          ls -l "$HOME"/.docker/config.json
           docker --version
+          ls -l "$HOME"/.docker/config.json
           echo "${REGISTRY_TOKEN}" | docker login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
+          ls -l "$HOME"/.docker/config.json
 
       - name: 'logout (ghcr.io)'
         run: |
+          ls -l "$HOME"/.docker/config.json
           podman logout "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
+          ls -l "$HOME"/.docker/config.json
           docker logout "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
+          ls -l "$HOME"/.docker/config.json
 
       - name: 'login (ghcr.io) as repo owner'
         env:
@@ -44,8 +51,11 @@ jobs:
 
       - name: 'logout (ghcr.io)'
         run: |
+          ls -l "$HOME"/.docker/config.json
           podman logout "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
+          ls -l "$HOME"/.docker/config.json
           docker logout "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
+          ls -l "$HOME"/.docker/config.json
 
   verify_secrets_registries:
     name: 'Verify credentials (docker hub, quay)'
@@ -57,13 +67,19 @@ jobs:
           DOCKER_HUB_USER: '${{ secrets.DOCKER_HUB_USER }}'
           DOCKER_HUB_TOKEN: '${{ secrets.DOCKER_HUB_TOKEN }}'
         run: |
+          ls -l "$HOME"/.docker/config.json
           echo "${DOCKER_HUB_TOKEN}" | podman login -u "${DOCKER_HUB_USER}" --password-stdin docker.io
+          ls -l "$HOME"/.docker/config.json
           echo "${DOCKER_HUB_TOKEN}" | docker login -u "${DOCKER_HUB_USER}" --password-stdin
+          ls -l "$HOME"/.docker/config.json
 
       - name: 'logout (docker.io)'
         run: |
+          ls -l "$HOME"/.docker/config.json
           podman logout docker.io
+          ls -l "$HOME"/.docker/config.json
           docker logout
+          ls -l "$HOME"/.docker/config.json
 
       - name: 'login (quay.io)'
         env:
@@ -75,8 +91,11 @@ jobs:
 
       - name: 'logout (quay.io)'
         run: |
+          ls -l "$HOME"/.docker/config.json
           podman logout quay.io
+          ls -l "$HOME"/.docker/config.json
           docker logout quay.io
+          ls -l "$HOME"/.docker/config.json
 
   build_multi_ci:
     name: 'build_multi_ci'

--- a/.github/workflows/build_latest_release_multi.yml
+++ b/.github/workflows/build_latest_release_multi.yml
@@ -24,7 +24,6 @@ jobs:
           REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         run: |
           echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
-          echo "${REGISTRY_TOKEN}" | docker login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
 
       - name: 'login docker hub'
         env:

--- a/.github/workflows/build_latest_release_multi.yml
+++ b/.github/workflows/build_latest_release_multi.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: 'login ghcr.io'
         env:
-          REGISTRY_USER: '${{ github.actor }}'
+          REGISTRY_USER: '${{ github.repository_owner }}'
           REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         run: |
           echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"

--- a/.github/workflows/build_latest_release_multi.yml
+++ b/.github/workflows/build_latest_release_multi.yml
@@ -44,8 +44,10 @@ jobs:
 
       - name: 'build multi image'
         run: buildah unshare make branch_or_ref="$TAG_REF" release_tag="$REL" multibuild
+
       - name: 'test image'
         run: buildah unshare make dist_name=localhost/curl-multi release_tag="$REL" test
+
       - name: 'security scan image'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
@@ -55,8 +57,7 @@ jobs:
         env:
           REGISTRY_USER: '${{ github.actor }}'
           REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-        run: |
-          echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
+        run: echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
 
       - name: 'push images to github registry (ghcr.io)'
         run: |

--- a/.github/workflows/build_latest_release_multi.yml
+++ b/.github/workflows/build_latest_release_multi.yml
@@ -42,6 +42,11 @@ jobs:
       - name: 'install prereqs'
         run: /home/linuxbrew/.linuxbrew/bin/brew install cosign grype trivy
 
+      - name: 'versions'
+        run: |
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+          podman --version; docker --version; cosign version
+
       - name: 'build multi image'
         run: buildah unshare make branch_or_ref="$TAG_REF" release_tag="$REL" multibuild
 

--- a/.github/workflows/build_latest_release_multi.yml
+++ b/.github/workflows/build_latest_release_multi.yml
@@ -62,14 +62,14 @@ jobs:
           release_image_tag="${rel//_/.}"
           echo "REL=$release_image_tag" >> "$GITHUB_ENV"
 
+      - name: 'install prereqs'
+        run: /home/linuxbrew/.linuxbrew/bin/brew install cosign grype trivy
+
       - name: 'build multi image'
         run: buildah unshare make branch_or_ref="$TAG_REF" release_tag="$REL" multibuild
 
       - name: 'test image'
         run: buildah unshare make dist_name=localhost/curl-multi release_tag="$REL" test
-
-      - name: 'install scan prereqs'
-        run: /home/linuxbrew/.linuxbrew/bin/brew install grype trivy
 
       - name: 'security scan image'
         run: |
@@ -81,19 +81,18 @@ jobs:
           buildah manifest push --format v2s2 --all curl-multi:"$REL" docker://ghcr.io/curl/curl-container/curl-multi:"$REL"
           buildah manifest push --format v2s2 --all curl-base-multi:"$REL" docker://ghcr.io/curl/curl-container/curl-base-multi:"$REL"
 
-      - name: 'install Cosign'
-        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
-
       - name: 'sign images with sigstore key'
         env:
           COSIGN_PASSWORD: '${{ secrets.COSIGN_PASSWORD }}'
           COSIGN_PRIVATE_KEY: '${{ secrets.COSIGN_PRIVATE_KEY }}'
         run: |
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl-multi:"$REL"
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl-base-multi:"$REL"
 
       - name: 'verify image with public key'
         run: |
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           cosign verify --key cosign.pub ghcr.io/curl/curl-container/curl-multi:"$REL"
           cosign verify --key cosign.pub ghcr.io/curl/curl-container/curl-base-multi:"$REL"
 
@@ -109,6 +108,7 @@ jobs:
           COSIGN_PASSWORD: '${{ secrets.COSIGN_PASSWORD }}'
           COSIGN_PRIVATE_KEY: '${{ secrets.COSIGN_PRIVATE_KEY }}'
         run: |
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin docker.io/curlimages/curl:"$REL"
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin docker.io/curlimages/curl:latest
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin docker.io/curlimages/curl-base:"$REL"
@@ -116,6 +116,7 @@ jobs:
 
       - name: 'verify image with public key'
         run: |
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           cosign verify --key cosign.pub docker.io/curlimages/curl:"$REL"
           cosign verify --key cosign.pub docker.io/curlimages/curl:latest
           cosign verify --key cosign.pub docker.io/curlimages/curl-base:"$REL"
@@ -133,6 +134,7 @@ jobs:
           COSIGN_PASSWORD: '${{ secrets.COSIGN_PASSWORD }}'
           COSIGN_PRIVATE_KEY: '${{ secrets.COSIGN_PRIVATE_KEY }}'
         run: |
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin quay.io/curl/curl:"$REL"
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin quay.io/curl/curl:latest
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin quay.io/curl/curl-base:"$REL"
@@ -140,6 +142,7 @@ jobs:
 
       - name: 'verify image with public key'
         run: |
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           cosign verify --key cosign.pub quay.io/curl/curl:"$REL"
           cosign verify --key cosign.pub quay.io/curl/curl:latest
           cosign verify --key cosign.pub quay.io/curl/curl-base:"$REL"

--- a/.github/workflows/build_latest_release_multi.yml
+++ b/.github/workflows/build_latest_release_multi.yml
@@ -53,11 +53,12 @@ jobs:
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           make image_name=localhost/curl-multi:"$REL" scan
 
+
       - name: 'login (ghcr.io)'
         env:
           REGISTRY_USER: '${{ github.actor }}'
           REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-        run: echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
+        run: echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin ghcr.io/"${GITHUB_REPOSITORY_OWNER}"
 
       - name: 'push images to github registry (ghcr.io)'
         run: |
@@ -74,7 +75,8 @@ jobs:
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl-base-multi:"$REL"
 
       - name: 'logout (ghcr.io)'
-        run: podman logout "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
+        run: podman logout ghcr.io/"${GITHUB_REPOSITORY_OWNER}"
+
 
       - name: 'login (docker.io)'
         env:
@@ -107,6 +109,7 @@ jobs:
           podman logout docker.io
           docker logout
 
+
       - name: 'login (quay.io)'
         env:
           QUAY_USER: '${{ secrets.QUAY_USER }}'
@@ -137,6 +140,7 @@ jobs:
         run: |
           podman logout quay.io
           docker logout quay.io
+
 
       - name: 'verify image with public key (ghcr.io)'
         run: |

--- a/.github/workflows/build_latest_release_multi.yml
+++ b/.github/workflows/build_latest_release_multi.yml
@@ -103,7 +103,9 @@ jobs:
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin docker.io/curlimages/curl-base:latest
 
       - name: 'logout (docker.io)'
-        run: docker logout
+        run: |
+          podman logout docker.io
+          docker logout
 
       - name: 'login (quay.io)'
         env:
@@ -132,7 +134,9 @@ jobs:
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin quay.io/curl/curl-base:latest
 
       - name: 'logout (docker.io)'
-        run: podman logout quay.io
+        run: |
+          podman logout quay.io
+          docker logout quay.io
 
       - name: 'verify image with public key (ghcr.io)'
         run: |

--- a/.github/workflows/build_latest_release_multi.yml
+++ b/.github/workflows/build_latest_release_multi.yml
@@ -51,19 +51,19 @@ jobs:
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           make image_name=localhost/curl-multi:"$REL" scan
 
-      - name: 'login ghcr.io'
+      - name: 'login (ghcr.io)'
         env:
           REGISTRY_USER: '${{ github.actor }}'
           REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         run: |
           echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
 
-      - name: 'push images to github registry'
+      - name: 'push images to github registry (ghcr.io)'
         run: |
           buildah manifest push --format v2s2 --all curl-multi:"$REL"      docker://ghcr.io/curl/curl-container/curl-multi:"$REL"
           buildah manifest push --format v2s2 --all curl-base-multi:"$REL" docker://ghcr.io/curl/curl-container/curl-base-multi:"$REL"
 
-      - name: 'sign images with sigstore key'
+      - name: 'sign images with sigstore key (ghcr.io)'
         env:
           COSIGN_PASSWORD: '${{ secrets.COSIGN_PASSWORD }}'
           COSIGN_PRIVATE_KEY: '${{ secrets.COSIGN_PRIVATE_KEY }}'
@@ -72,13 +72,13 @@ jobs:
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl-multi:"$REL"
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl-base-multi:"$REL"
 
-      - name: 'verify image with public key'
+      - name: 'verify image with public key (ghcr.io)'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           cosign verify --key cosign.pub ghcr.io/curl/curl-container/curl-multi:"$REL"
           cosign verify --key cosign.pub ghcr.io/curl/curl-container/curl-base-multi:"$REL"
 
-      - name: 'login docker hub'
+      - name: 'login (docker.io)'
         env:
           DOCKER_HUB_USER: '${{ secrets.DOCKER_HUB_USER }}'
           DOCKER_HUB_TOKEN: '${{ secrets.DOCKER_HUB_TOKEN }}'
@@ -86,14 +86,14 @@ jobs:
           echo "${DOCKER_HUB_TOKEN}" | podman login -u "${DOCKER_HUB_USER}" --password-stdin docker.io
           echo "${DOCKER_HUB_TOKEN}" | docker login -u "${DOCKER_HUB_USER}" --password-stdin
 
-      - name: 'push release to docker hub'
+      - name: 'push release to docker hub (docker.io)'
         run: |
           buildah manifest push --format v2s2 --all localhost/curl-multi:"$REL"      docker://docker.io/curlimages/curl:"$REL"
           buildah manifest push --format v2s2 --all localhost/curl-multi:"$REL"      docker://docker.io/curlimages/curl:latest
           buildah manifest push --format v2s2 --all localhost/curl-base-multi:"$REL" docker://docker.io/curlimages/curl-base:"$REL"
           buildah manifest push --format v2s2 --all localhost/curl-base-multi:"$REL" docker://docker.io/curlimages/curl-base:latest
 
-      - name: 'sign images with a sigstore key'
+      - name: 'sign images with a sigstore key (docker.io)'
         env:
           COSIGN_PASSWORD: '${{ secrets.COSIGN_PASSWORD }}'
           COSIGN_PRIVATE_KEY: '${{ secrets.COSIGN_PRIVATE_KEY }}'
@@ -104,7 +104,7 @@ jobs:
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin docker.io/curlimages/curl-base:"$REL"
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin docker.io/curlimages/curl-base:latest
 
-      - name: 'verify image with public key'
+      - name: 'verify image with public key (docker.io)'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           cosign verify --key cosign.pub docker.io/curlimages/curl:"$REL"
@@ -112,7 +112,7 @@ jobs:
           cosign verify --key cosign.pub docker.io/curlimages/curl-base:"$REL"
           cosign verify --key cosign.pub docker.io/curlimages/curl-base:latest
 
-      - name: 'login quay.io'
+      - name: 'login (quay.io)'
         env:
           QUAY_USER: '${{ secrets.QUAY_USER }}'
           QUAY_TOKEN: '${{ secrets.QUAY_TOKEN }}'
@@ -120,14 +120,14 @@ jobs:
           echo "${QUAY_TOKEN}" | podman login -u "${QUAY_USER}" --password-stdin quay.io
           echo "${QUAY_TOKEN}" | docker login -u "${QUAY_USER}" --password-stdin quay.io
 
-      - name: 'push release to quay.io'
+      - name: 'push release (quay.io)'
         run: |
           buildah manifest push --format v2s2 --all localhost/curl-multi:"$REL"      docker://quay.io/curl/curl:"$REL"
           buildah manifest push --format v2s2 --all localhost/curl-multi:"$REL"      docker://quay.io/curl/curl:latest
           buildah manifest push --format v2s2 --all localhost/curl-base-multi:"$REL" docker://quay.io/curl/curl-base:"$REL"
           buildah manifest push --format v2s2 --all localhost/curl-base-multi:"$REL" docker://quay.io/curl/curl-base:latest
 
-      - name: 'sign images with a sigstore key'
+      - name: 'sign images with a sigstore key (quay.io)'
         env:
           COSIGN_PASSWORD: '${{ secrets.COSIGN_PASSWORD }}'
           COSIGN_PRIVATE_KEY: '${{ secrets.COSIGN_PRIVATE_KEY }}'
@@ -138,7 +138,7 @@ jobs:
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin quay.io/curl/curl-base:"$REL"
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin quay.io/curl/curl-base:latest
 
-      - name: 'verify image with public key'
+      - name: 'verify image with public key (quay.io)'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           cosign verify --key cosign.pub quay.io/curl/curl:"$REL"

--- a/.github/workflows/build_latest_release_multi.yml
+++ b/.github/workflows/build_latest_release_multi.yml
@@ -53,7 +53,6 @@ jobs:
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           make image_name=localhost/curl-multi:"$REL" scan
 
-
       - name: 'login (ghcr.io)'
         env:
           REGISTRY_USER: '${{ github.actor }}'
@@ -76,7 +75,6 @@ jobs:
 
       - name: 'logout (ghcr.io)'
         run: podman logout ghcr.io/"${GITHUB_REPOSITORY_OWNER}"
-
 
       - name: 'login (docker.io)'
         env:
@@ -109,7 +107,6 @@ jobs:
           podman logout docker.io
           docker logout
 
-
       - name: 'login (quay.io)'
         env:
           QUAY_USER: '${{ secrets.QUAY_USER }}'
@@ -140,7 +137,6 @@ jobs:
         run: |
           podman logout quay.io
           docker logout quay.io
-
 
       - name: 'verify image with public key (ghcr.io)'
         run: |

--- a/.github/workflows/build_latest_release_multi.yml
+++ b/.github/workflows/build_latest_release_multi.yml
@@ -72,12 +72,6 @@ jobs:
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl-multi:"$REL"
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl-base-multi:"$REL"
 
-      - name: 'verify image with public key (ghcr.io)'
-        run: |
-          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-          cosign verify --key cosign.pub ghcr.io/curl/curl-container/curl-multi:"$REL"
-          cosign verify --key cosign.pub ghcr.io/curl/curl-container/curl-base-multi:"$REL"
-
       - name: 'login (docker.io)'
         env:
           DOCKER_HUB_USER: '${{ secrets.DOCKER_HUB_USER }}'
@@ -103,14 +97,6 @@ jobs:
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin docker.io/curlimages/curl:latest
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin docker.io/curlimages/curl-base:"$REL"
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin docker.io/curlimages/curl-base:latest
-
-      - name: 'verify image with public key (docker.io)'
-        run: |
-          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-          cosign verify --key cosign.pub docker.io/curlimages/curl:"$REL"
-          cosign verify --key cosign.pub docker.io/curlimages/curl:latest
-          cosign verify --key cosign.pub docker.io/curlimages/curl-base:"$REL"
-          cosign verify --key cosign.pub docker.io/curlimages/curl-base:latest
 
       - name: 'login (quay.io)'
         env:
@@ -138,6 +124,12 @@ jobs:
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin quay.io/curl/curl-base:"$REL"
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin quay.io/curl/curl-base:latest
 
+      - name: 'verify image with public key (ghcr.io)'
+        run: |
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+          cosign verify --key cosign.pub ghcr.io/curl/curl-container/curl-multi:"$REL"
+          cosign verify --key cosign.pub ghcr.io/curl/curl-container/curl-base-multi:"$REL"
+
       - name: 'verify image with public key (quay.io)'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
@@ -145,3 +137,12 @@ jobs:
           cosign verify --key cosign.pub quay.io/curl/curl:latest
           cosign verify --key cosign.pub quay.io/curl/curl-base:"$REL"
           cosign verify --key cosign.pub quay.io/curl/curl-base:latest
+
+      - name: 'verify image with public key (docker.io)'
+        # Seen flaky with 'Error: no signatures found' (with cosign v3.0.2). Do it last to let other steps finish.
+        run: |
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+          cosign verify --key cosign.pub docker.io/curlimages/curl:"$REL"
+          cosign verify --key cosign.pub docker.io/curlimages/curl:latest
+          cosign verify --key cosign.pub docker.io/curlimages/curl-base:"$REL"
+          cosign verify --key cosign.pub docker.io/curlimages/curl-base:latest

--- a/.github/workflows/build_latest_release_multi.yml
+++ b/.github/workflows/build_latest_release_multi.yml
@@ -98,6 +98,12 @@ jobs:
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin docker.io/curlimages/curl:latest
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin docker.io/curlimages/curl-base:"$REL"
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin docker.io/curlimages/curl-base:latest
+      - name: 'verify image with public key'
+        run: |
+          cosign verify --key cosign.pub docker.io/curlimages/curl:"$REL"
+          cosign verify --key cosign.pub docker.io/curlimages/curl:latest
+          cosign verify --key cosign.pub docker.io/curlimages/curl-base:"$REL"
+          cosign verify --key cosign.pub docker.io/curlimages/curl-base:latest
       - name: 'push release to quay.io'
         run: |
           buildah manifest push --format v2s2 --all localhost/curl-multi:"$REL" docker://quay.io/curl/curl:"$REL"
@@ -113,13 +119,7 @@ jobs:
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin quay.io/curl/curl:latest
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin quay.io/curl/curl-base:"$REL"
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin quay.io/curl/curl-base:latest
-      - name: 'verify docker image with public key'
-        run: |
-          cosign verify --key cosign.pub docker.io/curlimages/curl:"$REL"
-          cosign verify --key cosign.pub docker.io/curlimages/curl:latest
-          cosign verify --key cosign.pub docker.io/curlimages/curl-base:"$REL"
-          cosign verify --key cosign.pub docker.io/curlimages/curl-base:latest
-      - name: 'verify quay image with public key'
+      - name: 'verify image with public key'
         run: |
           cosign verify --key cosign.pub quay.io/curl/curl:"$REL"
           cosign verify --key cosign.pub quay.io/curl/curl:latest

--- a/.github/workflows/build_latest_release_multi.yml
+++ b/.github/workflows/build_latest_release_multi.yml
@@ -62,8 +62,8 @@ jobs:
 
       - name: 'push images to github registry (ghcr.io)'
         run: |
-          buildah manifest push --format v2s2 --all curl-multi:"$REL"      docker://ghcr.io/curl/curl-container/curl-multi:"$REL"
-          buildah manifest push --format v2s2 --all curl-base-multi:"$REL" docker://ghcr.io/curl/curl-container/curl-base-multi:"$REL"
+          buildah manifest push --format v2s2 --all curl-multi:"$REL"      docker://ghcr.io/${GITHUB_REPOSITORY}/curl-multi:"$REL"
+          buildah manifest push --format v2s2 --all curl-base-multi:"$REL" docker://ghcr.io/${GITHUB_REPOSITORY}/curl-base-multi:"$REL"
 
       - name: 'sign images with sigstore key (ghcr.io)'
         env:
@@ -71,8 +71,8 @@ jobs:
           COSIGN_PRIVATE_KEY: '${{ secrets.COSIGN_PRIVATE_KEY }}'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-          echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl-multi:"$REL"
-          echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl-base-multi:"$REL"
+          echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/${GITHUB_REPOSITORY}/curl-multi:"$REL"
+          echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/${GITHUB_REPOSITORY}/curl-base-multi:"$REL"
 
       - name: 'logout (ghcr.io)'
         run: podman logout ghcr.io/"${GITHUB_REPOSITORY_OWNER}"
@@ -145,8 +145,8 @@ jobs:
       - name: 'verify image with public key (ghcr.io)'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-          cosign verify --key cosign.pub ghcr.io/curl/curl-container/curl-multi:"$REL"
-          cosign verify --key cosign.pub ghcr.io/curl/curl-container/curl-base-multi:"$REL"
+          cosign verify --key cosign.pub ghcr.io/${GITHUB_REPOSITORY}/curl-multi:"$REL"
+          cosign verify --key cosign.pub ghcr.io/${GITHUB_REPOSITORY}/curl-base-multi:"$REL"
 
       - name: 'verify image with public key (quay.io)'
         run: |

--- a/.github/workflows/build_latest_release_multi.yml
+++ b/.github/workflows/build_latest_release_multi.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: 'login ghcr.io'
         env:
-          REGISTRY_USER: '${{ github.repository_owner }}'
+          REGISTRY_USER: '${{ github.actor }}'
           REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         run: |
           echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"

--- a/.github/workflows/build_latest_release_multi.yml
+++ b/.github/workflows/build_latest_release_multi.yml
@@ -18,29 +18,6 @@ jobs:
     permissions:
       packages: write  # To create/update container on ghcr.io
     steps:
-      - name: 'login ghcr.io'
-        env:
-          REGISTRY_USER: '${{ github.actor }}'
-          REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-        run: |
-          echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
-
-      - name: 'login docker hub'
-        env:
-          DOCKER_HUB_USER: '${{ secrets.DOCKER_HUB_USER }}'
-          DOCKER_HUB_TOKEN: '${{ secrets.DOCKER_HUB_TOKEN }}'
-        run: |
-          echo "${DOCKER_HUB_TOKEN}" | podman login -u "${DOCKER_HUB_USER}" --password-stdin docker.io
-          echo "${DOCKER_HUB_TOKEN}" | docker login -u "${DOCKER_HUB_USER}" --password-stdin
-
-      - name: 'login quay.io'
-        env:
-          QUAY_USER: '${{ secrets.QUAY_USER }}'
-          QUAY_TOKEN: '${{ secrets.QUAY_TOKEN }}'
-        run: |
-          echo "${QUAY_TOKEN}" | podman login -u "${QUAY_USER}" --password-stdin quay.io
-          echo "${QUAY_TOKEN}" | docker login -u "${QUAY_USER}" --password-stdin quay.io
-
       - name: 'install dev deps'
         run: |
           sudo rm -f /etc/apt/sources.list.d/{azure-cli.sources,microsoft-prod.list,ondrej-ubuntu-php-noble.sources}
@@ -76,6 +53,13 @@ jobs:
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           make image_name=localhost/curl-multi:"$REL" scan
 
+      - name: 'login ghcr.io'
+        env:
+          REGISTRY_USER: '${{ github.actor }}'
+          REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+        run: |
+          echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
+
       - name: 'push images to github registry'
         run: |
           buildah manifest push --format v2s2 --all curl-multi:"$REL"      docker://ghcr.io/curl/curl-container/curl-multi:"$REL"
@@ -95,6 +79,14 @@ jobs:
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           cosign verify --key cosign.pub ghcr.io/curl/curl-container/curl-multi:"$REL"
           cosign verify --key cosign.pub ghcr.io/curl/curl-container/curl-base-multi:"$REL"
+
+      - name: 'login docker hub'
+        env:
+          DOCKER_HUB_USER: '${{ secrets.DOCKER_HUB_USER }}'
+          DOCKER_HUB_TOKEN: '${{ secrets.DOCKER_HUB_TOKEN }}'
+        run: |
+          echo "${DOCKER_HUB_TOKEN}" | podman login -u "${DOCKER_HUB_USER}" --password-stdin docker.io
+          echo "${DOCKER_HUB_TOKEN}" | docker login -u "${DOCKER_HUB_USER}" --password-stdin
 
       - name: 'push release to docker hub'
         run: |
@@ -121,6 +113,14 @@ jobs:
           cosign verify --key cosign.pub docker.io/curlimages/curl:latest
           cosign verify --key cosign.pub docker.io/curlimages/curl-base:"$REL"
           cosign verify --key cosign.pub docker.io/curlimages/curl-base:latest
+
+      - name: 'login quay.io'
+        env:
+          QUAY_USER: '${{ secrets.QUAY_USER }}'
+          QUAY_TOKEN: '${{ secrets.QUAY_TOKEN }}'
+        run: |
+          echo "${QUAY_TOKEN}" | podman login -u "${QUAY_USER}" --password-stdin quay.io
+          echo "${QUAY_TOKEN}" | docker login -u "${QUAY_USER}" --password-stdin quay.io
 
       - name: 'push release to quay.io'
         run: |

--- a/.github/workflows/build_latest_release_multi.yml
+++ b/.github/workflows/build_latest_release_multi.yml
@@ -19,11 +19,12 @@ jobs:
       packages: write  # To create/update container on ghcr.io
     steps:
       - name: 'login ghcr.io'
-        uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7
-        with:
-          username: '${{ github.actor }}'
-          password: '${{ secrets.GITHUB_TOKEN }}'
-          registry: 'ghcr.io/${{ github.repository_owner }}'
+        env:
+          REGISTRY_USER: '${{ github.actor }}'
+          REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+        run: |
+          echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
+          echo "${REGISTRY_TOKEN}" | docker login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
 
       - name: 'login docker hub'
         env:

--- a/.github/workflows/build_latest_release_multi.yml
+++ b/.github/workflows/build_latest_release_multi.yml
@@ -156,7 +156,7 @@ jobs:
         # Seen flaky with 'Error: no signatures found' (with cosign v3.0.2). Do it last to let other steps finish.
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-          cosign verify --key cosign.pub docker.io/curlimages/curl:"$REL"
-          cosign verify --key cosign.pub docker.io/curlimages/curl:latest
-          cosign verify --key cosign.pub docker.io/curlimages/curl-base:"$REL"
-          cosign verify --key cosign.pub docker.io/curlimages/curl-base:latest
+          cosign -d verify --key cosign.pub docker.io/curlimages/curl:"$REL"
+          cosign -d verify --key cosign.pub docker.io/curlimages/curl:latest
+          cosign -d verify --key cosign.pub docker.io/curlimages/curl-base:"$REL"
+          cosign -d verify --key cosign.pub docker.io/curlimages/curl-base:latest

--- a/.github/workflows/build_latest_release_multi.yml
+++ b/.github/workflows/build_latest_release_multi.yml
@@ -44,10 +44,8 @@ jobs:
 
       - name: 'build multi image'
         run: buildah unshare make branch_or_ref="$TAG_REF" release_tag="$REL" multibuild
-
       - name: 'test image'
         run: buildah unshare make dist_name=localhost/curl-multi release_tag="$REL" test
-
       - name: 'security scan image'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"

--- a/.github/workflows/build_latest_release_multi.yml
+++ b/.github/workflows/build_latest_release_multi.yml
@@ -73,6 +73,9 @@ jobs:
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl-multi:"$REL"
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl-base-multi:"$REL"
 
+      - name: 'logout (ghcr.io)'
+        run: podman logout "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
+
       - name: 'login (docker.io)'
         env:
           DOCKER_HUB_USER: '${{ secrets.DOCKER_HUB_USER }}'
@@ -99,6 +102,9 @@ jobs:
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin docker.io/curlimages/curl-base:"$REL"
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin docker.io/curlimages/curl-base:latest
 
+      - name: 'logout (docker.io)'
+        run: docker logout
+
       - name: 'login (quay.io)'
         env:
           QUAY_USER: '${{ secrets.QUAY_USER }}'
@@ -124,6 +130,9 @@ jobs:
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin quay.io/curl/curl:latest
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin quay.io/curl/curl-base:"$REL"
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin quay.io/curl/curl-base:latest
+
+      - name: 'logout (docker.io)'
+        run: podman logout quay.io
 
       - name: 'verify image with public key (ghcr.io)'
         run: |

--- a/.github/workflows/build_latest_release_multi.yml
+++ b/.github/workflows/build_latest_release_multi.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: 'push images to github registry'
         run: |
-          buildah manifest push --format v2s2 --all curl-multi:"$REL" docker://ghcr.io/curl/curl-container/curl-multi:"$REL"
+          buildah manifest push --format v2s2 --all curl-multi:"$REL"      docker://ghcr.io/curl/curl-container/curl-multi:"$REL"
           buildah manifest push --format v2s2 --all curl-base-multi:"$REL" docker://ghcr.io/curl/curl-container/curl-base-multi:"$REL"
 
       - name: 'sign images with sigstore key'
@@ -98,8 +98,8 @@ jobs:
 
       - name: 'push release to docker hub'
         run: |
-          buildah manifest push --format v2s2 --all localhost/curl-multi:"$REL" docker://docker.io/curlimages/curl:"$REL"
-          buildah manifest push --format v2s2 --all localhost/curl-multi:"$REL" docker://docker.io/curlimages/curl:latest
+          buildah manifest push --format v2s2 --all localhost/curl-multi:"$REL"      docker://docker.io/curlimages/curl:"$REL"
+          buildah manifest push --format v2s2 --all localhost/curl-multi:"$REL"      docker://docker.io/curlimages/curl:latest
           buildah manifest push --format v2s2 --all localhost/curl-base-multi:"$REL" docker://docker.io/curlimages/curl-base:"$REL"
           buildah manifest push --format v2s2 --all localhost/curl-base-multi:"$REL" docker://docker.io/curlimages/curl-base:latest
 
@@ -124,8 +124,8 @@ jobs:
 
       - name: 'push release to quay.io'
         run: |
-          buildah manifest push --format v2s2 --all localhost/curl-multi:"$REL" docker://quay.io/curl/curl:"$REL"
-          buildah manifest push --format v2s2 --all localhost/curl-multi:"$REL" docker://quay.io/curl/curl:latest
+          buildah manifest push --format v2s2 --all localhost/curl-multi:"$REL"      docker://quay.io/curl/curl:"$REL"
+          buildah manifest push --format v2s2 --all localhost/curl-multi:"$REL"      docker://quay.io/curl/curl:latest
           buildah manifest push --format v2s2 --all localhost/curl-base-multi:"$REL" docker://quay.io/curl/curl-base:"$REL"
           buildah manifest push --format v2s2 --all localhost/curl-base-multi:"$REL" docker://quay.io/curl/curl-base:latest
 

--- a/.github/workflows/build_latest_release_multi.yml
+++ b/.github/workflows/build_latest_release_multi.yml
@@ -24,6 +24,7 @@ jobs:
           username: '${{ github.actor }}'
           password: '${{ secrets.GITHUB_TOKEN }}'
           registry: 'ghcr.io/${{ github.repository_owner }}'
+
       - name: 'login docker hub'
         env:
           DOCKER_HUB_USER: '${{ secrets.DOCKER_HUB_USER }}'
@@ -31,6 +32,7 @@ jobs:
         run: |
           echo "${DOCKER_HUB_TOKEN}" | podman login -u "${DOCKER_HUB_USER}" --password-stdin docker.io
           echo "${DOCKER_HUB_TOKEN}" | docker login -u "${DOCKER_HUB_USER}" --password-stdin
+
       - name: 'login quay.io'
         env:
           QUAY_USER: '${{ secrets.QUAY_USER }}'
@@ -38,16 +40,19 @@ jobs:
         run: |
           echo "${QUAY_TOKEN}" | podman login -u "${QUAY_USER}" --password-stdin quay.io
           echo "${QUAY_TOKEN}" | docker login -u "${QUAY_USER}" --password-stdin quay.io
+
       - name: 'install dev deps'
         run: |
           sudo rm -f /etc/apt/sources.list.d/{azure-cli.sources,microsoft-prod.list,ondrej-ubuntu-php-noble.sources}
           sudo apt-get -o Dpkg::Use-Pty=0 update
           sudo apt-get -o Dpkg::Use-Pty=0 install \
             qemu-user-static buildah less git make podman clamav clamav-freshclam
+
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           persist-credentials: false
           tag_name: ${{ github.ref }}
+
       - name: 'set env vars'
         run: |
           release_tag_redirect=$(curl -s https://github.com/curl/curl/releases/latest -w'%{redirect_url}\n' -o /dev/null)
@@ -56,22 +61,29 @@ jobs:
           rel=${latest_release_ref:5}
           release_image_tag="${rel//_/.}"
           echo "REL=$release_image_tag" >> "$GITHUB_ENV"
+
       - name: 'build multi image'
         run: buildah unshare make branch_or_ref="$TAG_REF" release_tag="$REL" multibuild
+
       - name: 'test image'
         run: buildah unshare make dist_name=localhost/curl-multi release_tag="$REL" test
+
       - name: 'install scan prereqs'
         run: /home/linuxbrew/.linuxbrew/bin/brew install grype trivy
+
       - name: 'security scan image'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           make image_name=localhost/curl-multi:"$REL" scan
+
       - name: 'push images to github registry'
         run: |
           buildah manifest push --format v2s2 --all curl-multi:"$REL" docker://ghcr.io/curl/curl-container/curl-multi:"$REL"
           buildah manifest push --format v2s2 --all curl-base-multi:"$REL" docker://ghcr.io/curl/curl-container/curl-base-multi:"$REL"
+
       - name: 'install Cosign'
         uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
+
       - name: 'sign images with sigstore key'
         env:
           COSIGN_PASSWORD: '${{ secrets.COSIGN_PASSWORD }}'
@@ -79,16 +91,19 @@ jobs:
         run: |
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl-multi:"$REL"
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl-base-multi:"$REL"
+
       - name: 'verify image with public key'
         run: |
           cosign verify --key cosign.pub ghcr.io/curl/curl-container/curl-multi:"$REL"
           cosign verify --key cosign.pub ghcr.io/curl/curl-container/curl-base-multi:"$REL"
+
       - name: 'push release to docker hub'
         run: |
           buildah manifest push --format v2s2 --all localhost/curl-multi:"$REL" docker://docker.io/curlimages/curl:"$REL"
           buildah manifest push --format v2s2 --all localhost/curl-multi:"$REL" docker://docker.io/curlimages/curl:latest
           buildah manifest push --format v2s2 --all localhost/curl-base-multi:"$REL" docker://docker.io/curlimages/curl-base:"$REL"
           buildah manifest push --format v2s2 --all localhost/curl-base-multi:"$REL" docker://docker.io/curlimages/curl-base:latest
+
       - name: 'sign images with a sigstore key'
         env:
           COSIGN_PASSWORD: '${{ secrets.COSIGN_PASSWORD }}'
@@ -98,18 +113,21 @@ jobs:
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin docker.io/curlimages/curl:latest
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin docker.io/curlimages/curl-base:"$REL"
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin docker.io/curlimages/curl-base:latest
+
       - name: 'verify image with public key'
         run: |
           cosign verify --key cosign.pub docker.io/curlimages/curl:"$REL"
           cosign verify --key cosign.pub docker.io/curlimages/curl:latest
           cosign verify --key cosign.pub docker.io/curlimages/curl-base:"$REL"
           cosign verify --key cosign.pub docker.io/curlimages/curl-base:latest
+
       - name: 'push release to quay.io'
         run: |
           buildah manifest push --format v2s2 --all localhost/curl-multi:"$REL" docker://quay.io/curl/curl:"$REL"
           buildah manifest push --format v2s2 --all localhost/curl-multi:"$REL" docker://quay.io/curl/curl:latest
           buildah manifest push --format v2s2 --all localhost/curl-base-multi:"$REL" docker://quay.io/curl/curl-base:"$REL"
           buildah manifest push --format v2s2 --all localhost/curl-base-multi:"$REL" docker://quay.io/curl/curl-base:latest
+
       - name: 'sign images with a sigstore key'
         env:
           COSIGN_PASSWORD: '${{ secrets.COSIGN_PASSWORD }}'
@@ -119,6 +137,7 @@ jobs:
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin quay.io/curl/curl:latest
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin quay.io/curl/curl-base:"$REL"
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin quay.io/curl/curl-base:latest
+
       - name: 'verify image with public key'
         run: |
           cosign verify --key cosign.pub quay.io/curl/curl:"$REL"

--- a/.github/workflows/build_latest_release_multi.yml
+++ b/.github/workflows/build_latest_release_multi.yml
@@ -133,7 +133,7 @@ jobs:
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin quay.io/curl/curl-base:"$REL"
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin quay.io/curl/curl-base:latest
 
-      - name: 'logout (docker.io)'
+      - name: 'logout (quay.io)'
         run: |
           podman logout quay.io
           docker logout quay.io

--- a/.github/workflows/build_latest_release_multi.yml
+++ b/.github/workflows/build_latest_release_multi.yml
@@ -62,8 +62,8 @@ jobs:
 
       - name: 'push images to github registry (ghcr.io)'
         run: |
-          buildah manifest push --format v2s2 --all curl-multi:"$REL"      docker://ghcr.io/${GITHUB_REPOSITORY}/curl-multi:"$REL"
-          buildah manifest push --format v2s2 --all curl-base-multi:"$REL" docker://ghcr.io/${GITHUB_REPOSITORY}/curl-base-multi:"$REL"
+          buildah manifest push --format v2s2 --all curl-multi:"$REL"      docker://ghcr.io/"${GITHUB_REPOSITORY}"/curl-multi:"$REL"
+          buildah manifest push --format v2s2 --all curl-base-multi:"$REL" docker://ghcr.io/"${GITHUB_REPOSITORY}"/curl-base-multi:"$REL"
 
       - name: 'sign images with sigstore key (ghcr.io)'
         env:
@@ -71,8 +71,8 @@ jobs:
           COSIGN_PRIVATE_KEY: '${{ secrets.COSIGN_PRIVATE_KEY }}'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-          echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/${GITHUB_REPOSITORY}/curl-multi:"$REL"
-          echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/${GITHUB_REPOSITORY}/curl-base-multi:"$REL"
+          echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/"${GITHUB_REPOSITORY}"/curl-multi:"$REL"
+          echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/"${GITHUB_REPOSITORY}"/curl-base-multi:"$REL"
 
       - name: 'logout (ghcr.io)'
         run: podman logout ghcr.io/"${GITHUB_REPOSITORY_OWNER}"
@@ -145,8 +145,8 @@ jobs:
       - name: 'verify image with public key (ghcr.io)'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-          cosign verify --key cosign.pub ghcr.io/${GITHUB_REPOSITORY}/curl-multi:"$REL"
-          cosign verify --key cosign.pub ghcr.io/${GITHUB_REPOSITORY}/curl-base-multi:"$REL"
+          cosign verify --key cosign.pub ghcr.io/"${GITHUB_REPOSITORY}"/curl-multi:"$REL"
+          cosign verify --key cosign.pub ghcr.io/"${GITHUB_REPOSITORY}"/curl-base-multi:"$REL"
 
       - name: 'verify image with public key (quay.io)'
         run: |

--- a/.github/workflows/build_master.yml
+++ b/.github/workflows/build_master.yml
@@ -27,6 +27,7 @@ jobs:
           username: '${{ github.actor }}'
           password: '${{ secrets.GITHUB_TOKEN }}'
           registry: 'ghcr.io/${{ github.repository_owner }}'
+
       - name: 'login docker hub'
         env:
           DOCKER_HUB_USER: '${{ secrets.DOCKER_HUB_USER }}'
@@ -34,6 +35,7 @@ jobs:
         run: |
           echo "${DOCKER_HUB_TOKEN}" | podman login -u "${DOCKER_HUB_USER}" --password-stdin docker.io
           echo "${DOCKER_HUB_TOKEN}" | docker login -u "${DOCKER_HUB_USER}" --password-stdin
+
       - name: 'login quay.io'
         env:
           QUAY_USER: '${{ secrets.QUAY_USER }}'
@@ -41,33 +43,42 @@ jobs:
         run: |
           echo "${QUAY_TOKEN}" | podman login -u "${QUAY_USER}" --password-stdin quay.io
           echo "${QUAY_TOKEN}" | docker login -u "${QUAY_USER}" --password-stdin quay.io
+
       - name: 'install dev deps'
         run: |
           sudo rm -f /etc/apt/sources.list.d/{azure-cli.sources,microsoft-prod.list,ondrej-ubuntu-php-noble.sources}
           sudo apt-get -o Dpkg::Use-Pty=0 update
           sudo apt-get -o Dpkg::Use-Pty=0 install \
             qemu-user-static buildah less git make podman clamav clamav-freshclam
+
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           persist-credentials: false
           ref: 'main'
+
       - name: 'build master images'
         run: buildah unshare make branch_or_ref=master release_tag=master build_ref_images
+
       - name: 'test image'
         run: buildah unshare make dist_name=localhost/curl release_tag=master test
+
       - name: 'install scan prereqs'
         run: /home/linuxbrew/.linuxbrew/bin/brew install grype trivy
+
       - name: 'security scan image'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           make image_name=localhost/curl:master scan
+
       - name: 'push images to github registry'
         run: |
           buildah push curl-dev:master "docker://ghcr.io/curl/curl-container/curl-dev:master"
           buildah push curl-base:master "docker://ghcr.io/curl/curl-container/curl-base:master"
           buildah push curl:master "docker://ghcr.io/curl/curl-container/curl:master"
+
       - name: 'install Cosign'
         uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
+
       - name: 'sign image with a key'
         env:
           COSIGN_PASSWORD: '${{ secrets.COSIGN_PASSWORD }}'
@@ -76,6 +87,7 @@ jobs:
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl-dev:master
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl-base:master
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl:master
+
       - name: 'verify image with public key'
         run: |
           cosign verify --key cosign.pub ghcr.io/curl/curl-container/curl-dev:master

--- a/.github/workflows/build_master.yml
+++ b/.github/workflows/build_master.yml
@@ -55,9 +55,9 @@ jobs:
 
       - name: 'push images to github registry (ghcr.io)'
         run: |
-          buildah push curl-dev:master  "docker://ghcr.io/curl/curl-container/curl-dev:master"
-          buildah push curl-base:master "docker://ghcr.io/curl/curl-container/curl-base:master"
-          buildah push curl:master      "docker://ghcr.io/curl/curl-container/curl:master"
+          buildah push curl-dev:master  "docker://ghcr.io/${GITHUB_REPOSITORY}/curl-dev:master"
+          buildah push curl-base:master "docker://ghcr.io/${GITHUB_REPOSITORY}/curl-base:master"
+          buildah push curl:master      "docker://ghcr.io/${GITHUB_REPOSITORY}/curl:master"
 
       - name: 'sign image with a key (ghcr.io)'
         env:
@@ -65,9 +65,9 @@ jobs:
           COSIGN_PRIVATE_KEY: '${{ secrets.COSIGN_PRIVATE_KEY }}'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-          echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl-dev:master
-          echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl-base:master
-          echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl:master
+          echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/${GITHUB_REPOSITORY}/curl-dev:master
+          echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/${GITHUB_REPOSITORY}/curl-base:master
+          echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/${GITHUB_REPOSITORY}/curl:master
 
       - name: 'logout (ghcr.io)'
         run: podman logout ghcr.io/"${GITHUB_REPOSITORY_OWNER}"
@@ -75,6 +75,6 @@ jobs:
       - name: 'verify image with public key (ghcr.io)'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-          cosign verify --key cosign.pub ghcr.io/curl/curl-container/curl-dev:master
-          cosign verify --key cosign.pub ghcr.io/curl/curl-container/curl-base:master
-          cosign verify --key cosign.pub ghcr.io/curl/curl-container/curl:master
+          cosign verify --key cosign.pub ghcr.io/${GITHUB_REPOSITORY}/curl-dev:master
+          cosign verify --key cosign.pub ghcr.io/${GITHUB_REPOSITORY}/curl-base:master
+          cosign verify --key cosign.pub ghcr.io/${GITHUB_REPOSITORY}/curl:master

--- a/.github/workflows/build_master.yml
+++ b/.github/workflows/build_master.yml
@@ -51,6 +51,9 @@ jobs:
           sudo apt-get -o Dpkg::Use-Pty=0 install \
             qemu-user-static buildah less git make podman clamav clamav-freshclam
 
+      - name: 'install prereqs'
+        run: /home/linuxbrew/.linuxbrew/bin/brew install cosign grype trivy
+
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           persist-credentials: false
@@ -61,9 +64,6 @@ jobs:
 
       - name: 'test image'
         run: buildah unshare make dist_name=localhost/curl release_tag=master test
-
-      - name: 'install scan prereqs'
-        run: /home/linuxbrew/.linuxbrew/bin/brew install grype trivy
 
       - name: 'security scan image'
         run: |
@@ -76,20 +76,19 @@ jobs:
           buildah push curl-base:master "docker://ghcr.io/curl/curl-container/curl-base:master"
           buildah push curl:master "docker://ghcr.io/curl/curl-container/curl:master"
 
-      - name: 'install Cosign'
-        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
-
       - name: 'sign image with a key'
         env:
           COSIGN_PASSWORD: '${{ secrets.COSIGN_PASSWORD }}'
           COSIGN_PRIVATE_KEY: '${{ secrets.COSIGN_PRIVATE_KEY }}'
         run: |
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl-dev:master
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl-base:master
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl:master
 
       - name: 'verify image with public key'
         run: |
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           cosign verify --key cosign.pub ghcr.io/curl/curl-container/curl-dev:master
           cosign verify --key cosign.pub ghcr.io/curl/curl-container/curl-base:master
           cosign verify --key cosign.pub ghcr.io/curl/curl-container/curl:master

--- a/.github/workflows/build_master.yml
+++ b/.github/workflows/build_master.yml
@@ -31,6 +31,11 @@ jobs:
       - name: 'install prereqs'
         run: /home/linuxbrew/.linuxbrew/bin/brew install cosign grype trivy
 
+      - name: 'versions'
+        run: |
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+          podman --version; docker --version; cosign version
+
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           persist-credentials: false

--- a/.github/workflows/build_master.yml
+++ b/.github/workflows/build_master.yml
@@ -21,13 +21,6 @@ jobs:
     permissions:
       packages: write  # To create/update container on ghcr.io
     steps:
-      - name: 'login ghcr.io'
-        env:
-          REGISTRY_USER: '${{ github.actor }}'
-          REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-        run: |
-          echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
-
       - name: 'install dev deps'
         run: |
           sudo rm -f /etc/apt/sources.list.d/{azure-cli.sources,microsoft-prod.list,ondrej-ubuntu-php-noble.sources}
@@ -53,6 +46,13 @@ jobs:
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           make image_name=localhost/curl:master scan
+
+      - name: 'login ghcr.io'
+        env:
+          REGISTRY_USER: '${{ github.actor }}'
+          REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+        run: |
+          echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
 
       - name: 'push images to github registry'
         run: |

--- a/.github/workflows/build_master.yml
+++ b/.github/workflows/build_master.yml
@@ -38,10 +38,8 @@ jobs:
 
       - name: 'build master images'
         run: buildah unshare make branch_or_ref=master release_tag=master build_ref_images
-
       - name: 'test image'
         run: buildah unshare make dist_name=localhost/curl release_tag=master test
-
       - name: 'security scan image'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"

--- a/.github/workflows/build_master.yml
+++ b/.github/workflows/build_master.yml
@@ -55,9 +55,9 @@ jobs:
 
       - name: 'push images to github registry (ghcr.io)'
         run: |
-          buildah push curl-dev:master  "docker://ghcr.io/${GITHUB_REPOSITORY}/curl-dev:master"
-          buildah push curl-base:master "docker://ghcr.io/${GITHUB_REPOSITORY}/curl-base:master"
-          buildah push curl:master      "docker://ghcr.io/${GITHUB_REPOSITORY}/curl:master"
+          buildah push curl-dev:master  docker://ghcr.io/"${GITHUB_REPOSITORY}"/curl-dev:master
+          buildah push curl-base:master docker://ghcr.io/"${GITHUB_REPOSITORY}"/curl-base:master
+          buildah push curl:master      docker://ghcr.io/"${GITHUB_REPOSITORY}"/curl:master
 
       - name: 'sign image with a key (ghcr.io)'
         env:
@@ -65,9 +65,9 @@ jobs:
           COSIGN_PRIVATE_KEY: '${{ secrets.COSIGN_PRIVATE_KEY }}'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-          echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/${GITHUB_REPOSITORY}/curl-dev:master
-          echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/${GITHUB_REPOSITORY}/curl-base:master
-          echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/${GITHUB_REPOSITORY}/curl:master
+          echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/"${GITHUB_REPOSITORY}"/curl-dev:master
+          echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/"${GITHUB_REPOSITORY}"/curl-base:master
+          echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/"${GITHUB_REPOSITORY}"/curl:master
 
       - name: 'logout (ghcr.io)'
         run: podman logout ghcr.io/"${GITHUB_REPOSITORY_OWNER}"
@@ -75,6 +75,6 @@ jobs:
       - name: 'verify image with public key (ghcr.io)'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-          cosign verify --key cosign.pub ghcr.io/${GITHUB_REPOSITORY}/curl-dev:master
-          cosign verify --key cosign.pub ghcr.io/${GITHUB_REPOSITORY}/curl-base:master
-          cosign verify --key cosign.pub ghcr.io/${GITHUB_REPOSITORY}/curl:master
+          cosign verify --key cosign.pub ghcr.io/"${GITHUB_REPOSITORY}"/curl-dev:master
+          cosign verify --key cosign.pub ghcr.io/"${GITHUB_REPOSITORY}"/curl-base:master
+          cosign verify --key cosign.pub ghcr.io/"${GITHUB_REPOSITORY}"/curl:master

--- a/.github/workflows/build_master.yml
+++ b/.github/workflows/build_master.yml
@@ -38,8 +38,10 @@ jobs:
 
       - name: 'build master images'
         run: buildah unshare make branch_or_ref=master release_tag=master build_ref_images
+
       - name: 'test image'
         run: buildah unshare make dist_name=localhost/curl release_tag=master test
+
       - name: 'security scan image'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
@@ -49,8 +51,7 @@ jobs:
         env:
           REGISTRY_USER: '${{ github.actor }}'
           REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-        run: |
-          echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
+        run: echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
 
       - name: 'push images to github registry (ghcr.io)'
         run: |

--- a/.github/workflows/build_master.yml
+++ b/.github/workflows/build_master.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: 'login ghcr.io'
         env:
-          REGISTRY_USER: '${{ github.repository_owner }}'
+          REGISTRY_USER: '${{ github.actor }}'
           REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         run: |
           echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"

--- a/.github/workflows/build_master.yml
+++ b/.github/workflows/build_master.yml
@@ -27,7 +27,6 @@ jobs:
           REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         run: |
           echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
-          echo "${REGISTRY_TOKEN}" | docker login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
 
       - name: 'login docker hub'
         env:

--- a/.github/workflows/build_master.yml
+++ b/.github/workflows/build_master.yml
@@ -22,11 +22,12 @@ jobs:
       packages: write  # To create/update container on ghcr.io
     steps:
       - name: 'login ghcr.io'
-        uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7
-        with:
-          username: '${{ github.actor }}'
-          password: '${{ secrets.GITHUB_TOKEN }}'
-          registry: 'ghcr.io/${{ github.repository_owner }}'
+        env:
+          REGISTRY_USER: '${{ github.actor }}'
+          REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+        run: |
+          echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
+          echo "${REGISTRY_TOKEN}" | docker login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
 
       - name: 'login docker hub'
         env:

--- a/.github/workflows/build_master.yml
+++ b/.github/workflows/build_master.yml
@@ -72,9 +72,9 @@ jobs:
 
       - name: 'push images to github registry'
         run: |
-          buildah push curl-dev:master "docker://ghcr.io/curl/curl-container/curl-dev:master"
+          buildah push curl-dev:master  "docker://ghcr.io/curl/curl-container/curl-dev:master"
           buildah push curl-base:master "docker://ghcr.io/curl/curl-container/curl-base:master"
-          buildah push curl:master "docker://ghcr.io/curl/curl-container/curl:master"
+          buildah push curl:master      "docker://ghcr.io/curl/curl-container/curl:master"
 
       - name: 'sign image with a key'
         env:

--- a/.github/workflows/build_master.yml
+++ b/.github/workflows/build_master.yml
@@ -69,6 +69,9 @@ jobs:
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl-base:master
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl:master
 
+      - name: 'logout (ghcr.io)'
+        run: podman logout "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
+
       - name: 'verify image with public key (ghcr.io)'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"

--- a/.github/workflows/build_master.yml
+++ b/.github/workflows/build_master.yml
@@ -51,7 +51,7 @@ jobs:
         env:
           REGISTRY_USER: '${{ github.actor }}'
           REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-        run: echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
+        run: echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin ghcr.io/"${GITHUB_REPOSITORY_OWNER}"
 
       - name: 'push images to github registry (ghcr.io)'
         run: |
@@ -70,7 +70,7 @@ jobs:
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl:master
 
       - name: 'logout (ghcr.io)'
-        run: podman logout "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
+        run: podman logout ghcr.io/"${GITHUB_REPOSITORY_OWNER}"
 
       - name: 'verify image with public key (ghcr.io)'
         run: |

--- a/.github/workflows/build_master.yml
+++ b/.github/workflows/build_master.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: 'login ghcr.io'
         env:
-          REGISTRY_USER: '${{ github.actor }}'
+          REGISTRY_USER: '${{ github.repository_owner }}'
           REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         run: |
           echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"

--- a/.github/workflows/build_master.yml
+++ b/.github/workflows/build_master.yml
@@ -28,22 +28,6 @@ jobs:
         run: |
           echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
 
-      - name: 'login docker hub'
-        env:
-          DOCKER_HUB_USER: '${{ secrets.DOCKER_HUB_USER }}'
-          DOCKER_HUB_TOKEN: '${{ secrets.DOCKER_HUB_TOKEN }}'
-        run: |
-          echo "${DOCKER_HUB_TOKEN}" | podman login -u "${DOCKER_HUB_USER}" --password-stdin docker.io
-          echo "${DOCKER_HUB_TOKEN}" | docker login -u "${DOCKER_HUB_USER}" --password-stdin
-
-      - name: 'login quay.io'
-        env:
-          QUAY_USER: '${{ secrets.QUAY_USER }}'
-          QUAY_TOKEN: '${{ secrets.QUAY_TOKEN }}'
-        run: |
-          echo "${QUAY_TOKEN}" | podman login -u "${QUAY_USER}" --password-stdin quay.io
-          echo "${QUAY_TOKEN}" | docker login -u "${QUAY_USER}" --password-stdin quay.io
-
       - name: 'install dev deps'
         run: |
           sudo rm -f /etc/apt/sources.list.d/{azure-cli.sources,microsoft-prod.list,ondrej-ubuntu-php-noble.sources}

--- a/.github/workflows/build_master.yml
+++ b/.github/workflows/build_master.yml
@@ -45,20 +45,20 @@ jobs:
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           make image_name=localhost/curl:master scan
 
-      - name: 'login ghcr.io'
+      - name: 'login (ghcr.io)'
         env:
           REGISTRY_USER: '${{ github.actor }}'
           REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         run: |
           echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
 
-      - name: 'push images to github registry'
+      - name: 'push images to github registry (ghcr.io)'
         run: |
           buildah push curl-dev:master  "docker://ghcr.io/curl/curl-container/curl-dev:master"
           buildah push curl-base:master "docker://ghcr.io/curl/curl-container/curl-base:master"
           buildah push curl:master      "docker://ghcr.io/curl/curl-container/curl:master"
 
-      - name: 'sign image with a key'
+      - name: 'sign image with a key (ghcr.io)'
         env:
           COSIGN_PASSWORD: '${{ secrets.COSIGN_PASSWORD }}'
           COSIGN_PRIVATE_KEY: '${{ secrets.COSIGN_PRIVATE_KEY }}'
@@ -68,7 +68,7 @@ jobs:
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl-base:master
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl:master
 
-      - name: 'verify image with public key'
+      - name: 'verify image with public key (ghcr.io)'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           cosign verify --key cosign.pub ghcr.io/curl/curl-container/curl-dev:master

--- a/.github/workflows/build_master_dev.yml
+++ b/.github/workflows/build_master_dev.yml
@@ -23,11 +23,13 @@ jobs:
       packages: write  # To create/update container on ghcr.io
     steps:
       - name: 'login ghcr.io'
-        uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7
-        with:
-          username: '${{ github.actor }}'
-          password: '${{ secrets.GITHUB_TOKEN }}'
-          registry: 'ghcr.io/${{ github.repository_owner }}'
+        env:
+          REGISTRY_USER: '${{ github.actor }}'
+          REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+        run: |
+          echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
+          echo "${REGISTRY_TOKEN}" | docker login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
+
       - name: 'login docker hub'
         env:
           DOCKER_HUB_USER: '${{ secrets.DOCKER_HUB_USER }}'

--- a/.github/workflows/build_master_dev.yml
+++ b/.github/workflows/build_master_dev.yml
@@ -29,22 +29,6 @@ jobs:
         run: |
           echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
 
-      - name: 'login docker hub'
-        env:
-          DOCKER_HUB_USER: '${{ secrets.DOCKER_HUB_USER }}'
-          DOCKER_HUB_TOKEN: '${{ secrets.DOCKER_HUB_TOKEN }}'
-        run: |
-          echo "${DOCKER_HUB_TOKEN}" | podman login -u "${DOCKER_HUB_USER}" --password-stdin docker.io
-          echo "${DOCKER_HUB_TOKEN}" | docker login -u "${DOCKER_HUB_USER}" --password-stdin
-
-      - name: 'login quay.io'
-        env:
-          QUAY_USER: '${{ secrets.QUAY_USER }}'
-          QUAY_TOKEN: '${{ secrets.QUAY_TOKEN }}'
-        run: |
-          echo "${QUAY_TOKEN}" | podman login -u "${QUAY_USER}" --password-stdin quay.io
-          echo "${QUAY_TOKEN}" | docker login -u "${QUAY_USER}" --password-stdin quay.io
-
       - name: 'install dev deps'
         run: |
           sudo rm -f /etc/apt/sources.list.d/{azure-cli.sources,microsoft-prod.list,ondrej-ubuntu-php-noble.sources}

--- a/.github/workflows/build_master_dev.yml
+++ b/.github/workflows/build_master_dev.yml
@@ -28,7 +28,6 @@ jobs:
           REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         run: |
           echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
-          echo "${REGISTRY_TOKEN}" | docker login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
 
       - name: 'login docker hub'
         env:

--- a/.github/workflows/build_master_dev.yml
+++ b/.github/workflows/build_master_dev.yml
@@ -49,7 +49,7 @@ jobs:
         env:
           REGISTRY_USER: '${{ github.actor }}'
           REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-        run: echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
+        run: echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin ghcr.io/"${GITHUB_REPOSITORY_OWNER}"
 
       - name: 'push images to github registry'
         run: buildah push curl-dev-debian:master "docker://ghcr.io/curl/curl-container/curl-dev-debian:master"
@@ -92,4 +92,4 @@ jobs:
           cosign verify --key cosign.pub ghcr.io/curl/curl-container/curl-dev-fedora:master
 
       - name: 'logout (ghcr.io)'
-        run: podman logout "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
+        run: podman logout ghcr.io/"${GITHUB_REPOSITORY_OWNER}"

--- a/.github/workflows/build_master_dev.yml
+++ b/.github/workflows/build_master_dev.yml
@@ -39,7 +39,6 @@ jobs:
 
       - name: 'build debian dev image'
         run: buildah unshare make branch_or_ref=master release_tag=master build_debian
-
       - name: 'security scan image'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
@@ -71,7 +70,6 @@ jobs:
 
       - name: 'build fedora dev image'
         run: buildah unshare make branch_or_ref=master release_tag=master build_fedora
-
       - name: 'security scan image'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"

--- a/.github/workflows/build_master_dev.yml
+++ b/.github/workflows/build_master_dev.yml
@@ -44,7 +44,7 @@ jobs:
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           make image_name=localhost/curl-dev-debian:master scan
 
-      - name: 'login ghcr.io'
+      - name: 'login (ghcr.io)'
         env:
           REGISTRY_USER: '${{ github.actor }}'
           REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/build_master_dev.yml
+++ b/.github/workflows/build_master_dev.yml
@@ -52,7 +52,7 @@ jobs:
         run: echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin ghcr.io/"${GITHUB_REPOSITORY_OWNER}"
 
       - name: 'push images to github registry'
-        run: buildah push curl-dev-debian:master "docker://ghcr.io/curl/curl-container/curl-dev-debian:master"
+        run: buildah push curl-dev-debian:master "docker://ghcr.io/${GITHUB_REPOSITORY}/curl-dev-debian:master"
 
       - name: 'sign image with a key'
         env:
@@ -60,12 +60,12 @@ jobs:
           COSIGN_PRIVATE_KEY: '${{ secrets.COSIGN_PRIVATE_KEY }}'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-          echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl-dev-debian:master
+          echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/${GITHUB_REPOSITORY}/curl-dev-debian:master
 
       - name: 'verify image with public key'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-          cosign verify --key cosign.pub ghcr.io/curl/curl-container/curl-dev-debian:master
+          cosign verify --key cosign.pub ghcr.io/${GITHUB_REPOSITORY}/curl-dev-debian:master
 
       - name: 'build fedora dev image'
         run: buildah unshare make branch_or_ref=master release_tag=master build_fedora
@@ -76,7 +76,7 @@ jobs:
           make image_name=localhost/curl-dev-fedora:master scan
 
       - name: 'push images to github registry'
-        run: buildah push curl-dev-fedora:master "docker://ghcr.io/curl/curl-container/curl-dev-fedora:master"
+        run: buildah push curl-dev-fedora:master "docker://ghcr.io/${GITHUB_REPOSITORY}/curl-dev-fedora:master"
 
       - name: 'sign image with a key'
         env:
@@ -84,12 +84,12 @@ jobs:
           COSIGN_PRIVATE_KEY: '${{ secrets.COSIGN_PRIVATE_KEY }}'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-          echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl-dev-fedora:master
+          echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/${GITHUB_REPOSITORY}/curl-dev-fedora:master
 
       - name: 'verify image with public key'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-          cosign verify --key cosign.pub ghcr.io/curl/curl-container/curl-dev-fedora:master
+          cosign verify --key cosign.pub ghcr.io/${GITHUB_REPOSITORY}/curl-dev-fedora:master
 
       - name: 'logout (ghcr.io)'
         run: podman logout ghcr.io/"${GITHUB_REPOSITORY_OWNER}"

--- a/.github/workflows/build_master_dev.yml
+++ b/.github/workflows/build_master_dev.yml
@@ -90,3 +90,6 @@ jobs:
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           cosign verify --key cosign.pub ghcr.io/curl/curl-container/curl-dev-fedora:master
+
+      - name: 'logout (ghcr.io)'
+        run: podman logout "ghcr.io/${GITHUB_REPOSITORY_OWNER}"

--- a/.github/workflows/build_master_dev.yml
+++ b/.github/workflows/build_master_dev.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: 'login ghcr.io'
         env:
-          REGISTRY_USER: '${{ github.actor }}'
+          REGISTRY_USER: '${{ github.repository_owner }}'
           REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         run: |
           echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"

--- a/.github/workflows/build_master_dev.yml
+++ b/.github/workflows/build_master_dev.yml
@@ -32,6 +32,11 @@ jobs:
       - name: 'install prereqs'
         run: /home/linuxbrew/.linuxbrew/bin/brew install cosign grype trivy
 
+      - name: 'versions'
+        run: |
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+          podman --version; docker --version; cosign version
+
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           persist-credentials: false

--- a/.github/workflows/build_master_dev.yml
+++ b/.github/workflows/build_master_dev.yml
@@ -52,7 +52,7 @@ jobs:
         run: echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin ghcr.io/"${GITHUB_REPOSITORY_OWNER}"
 
       - name: 'push images to github registry'
-        run: buildah push curl-dev-debian:master "docker://ghcr.io/${GITHUB_REPOSITORY}/curl-dev-debian:master"
+        run: buildah push curl-dev-debian:master docker://ghcr.io/"${GITHUB_REPOSITORY}"/curl-dev-debian:master
 
       - name: 'sign image with a key'
         env:
@@ -60,12 +60,12 @@ jobs:
           COSIGN_PRIVATE_KEY: '${{ secrets.COSIGN_PRIVATE_KEY }}'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-          echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/${GITHUB_REPOSITORY}/curl-dev-debian:master
+          echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/"${GITHUB_REPOSITORY}"/curl-dev-debian:master
 
       - name: 'verify image with public key'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-          cosign verify --key cosign.pub ghcr.io/${GITHUB_REPOSITORY}/curl-dev-debian:master
+          cosign verify --key cosign.pub ghcr.io/"${GITHUB_REPOSITORY}"/curl-dev-debian:master
 
       - name: 'build fedora dev image'
         run: buildah unshare make branch_or_ref=master release_tag=master build_fedora
@@ -76,7 +76,7 @@ jobs:
           make image_name=localhost/curl-dev-fedora:master scan
 
       - name: 'push images to github registry'
-        run: buildah push curl-dev-fedora:master "docker://ghcr.io/${GITHUB_REPOSITORY}/curl-dev-fedora:master"
+        run: buildah push curl-dev-fedora:master docker://ghcr.io/"${GITHUB_REPOSITORY}"/curl-dev-fedora:master
 
       - name: 'sign image with a key'
         env:
@@ -84,12 +84,12 @@ jobs:
           COSIGN_PRIVATE_KEY: '${{ secrets.COSIGN_PRIVATE_KEY }}'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-          echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/${GITHUB_REPOSITORY}/curl-dev-fedora:master
+          echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/"${GITHUB_REPOSITORY}"/curl-dev-fedora:master
 
       - name: 'verify image with public key'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-          cosign verify --key cosign.pub ghcr.io/${GITHUB_REPOSITORY}/curl-dev-fedora:master
+          cosign verify --key cosign.pub ghcr.io/"${GITHUB_REPOSITORY}"/curl-dev-fedora:master
 
       - name: 'logout (ghcr.io)'
         run: podman logout ghcr.io/"${GITHUB_REPOSITORY_OWNER}"

--- a/.github/workflows/build_master_dev.yml
+++ b/.github/workflows/build_master_dev.yml
@@ -52,6 +52,9 @@ jobs:
           sudo apt-get -o Dpkg::Use-Pty=0 install \
             qemu-user-static buildah less git make podman clamav clamav-freshclam
 
+      - name: 'install prereqs'
+        run: /home/linuxbrew/.linuxbrew/bin/brew install cosign grype trivy
+
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           persist-credentials: false
@@ -59,9 +62,6 @@ jobs:
 
       - name: 'build debian dev image'
         run: buildah unshare make branch_or_ref=master release_tag=master build_debian
-
-      - name: 'install scan prereqs'
-        run: /home/linuxbrew/.linuxbrew/bin/brew install grype trivy
 
       - name: 'security scan image'
         run: |
@@ -72,18 +72,17 @@ jobs:
         run: |
           buildah push curl-dev-debian:master "docker://ghcr.io/curl/curl-container/curl-dev-debian:master"
 
-      - name: 'install Cosign'
-        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
-
       - name: 'sign image with a key'
         env:
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
           COSIGN_PRIVATE_KEY: '${{ secrets.COSIGN_PRIVATE_KEY }}'
         run: |
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl-dev-debian:master
 
       - name: 'verify image with public key'
         run: |
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           cosign verify --key cosign.pub ghcr.io/curl/curl-container/curl-dev-debian:master
 
       - name: 'build fedora dev image'
@@ -103,8 +102,10 @@ jobs:
           COSIGN_PASSWORD: '${{ secrets.COSIGN_PASSWORD }}'
           COSIGN_PRIVATE_KEY: '${{ secrets.COSIGN_PRIVATE_KEY }}'
         run: |
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl-dev-fedora:master
 
       - name: 'verify image with public key'
         run: |
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           cosign verify --key cosign.pub ghcr.io/curl/curl-container/curl-dev-fedora:master

--- a/.github/workflows/build_master_dev.yml
+++ b/.github/workflows/build_master_dev.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: 'login ghcr.io'
         env:
-          REGISTRY_USER: '${{ github.repository_owner }}'
+          REGISTRY_USER: '${{ github.actor }}'
           REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         run: |
           echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"

--- a/.github/workflows/build_master_dev.yml
+++ b/.github/workflows/build_master_dev.yml
@@ -22,13 +22,6 @@ jobs:
     permissions:
       packages: write  # To create/update container on ghcr.io
     steps:
-      - name: 'login ghcr.io'
-        env:
-          REGISTRY_USER: '${{ github.actor }}'
-          REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-        run: |
-          echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
-
       - name: 'install dev deps'
         run: |
           sudo rm -f /etc/apt/sources.list.d/{azure-cli.sources,microsoft-prod.list,ondrej-ubuntu-php-noble.sources}
@@ -51,6 +44,13 @@ jobs:
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           make image_name=localhost/curl-dev-debian:master scan
+
+      - name: 'login ghcr.io'
+        env:
+          REGISTRY_USER: '${{ github.actor }}'
+          REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+        run: |
+          echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
 
       - name: 'push images to github registry'
         run: |

--- a/.github/workflows/build_master_dev.yml
+++ b/.github/workflows/build_master_dev.yml
@@ -39,6 +39,7 @@ jobs:
 
       - name: 'build debian dev image'
         run: buildah unshare make branch_or_ref=master release_tag=master build_debian
+
       - name: 'security scan image'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
@@ -48,12 +49,10 @@ jobs:
         env:
           REGISTRY_USER: '${{ github.actor }}'
           REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-        run: |
-          echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
+        run: echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
 
       - name: 'push images to github registry'
-        run: |
-          buildah push curl-dev-debian:master "docker://ghcr.io/curl/curl-container/curl-dev-debian:master"
+        run: buildah push curl-dev-debian:master "docker://ghcr.io/curl/curl-container/curl-dev-debian:master"
 
       - name: 'sign image with a key'
         env:
@@ -70,14 +69,14 @@ jobs:
 
       - name: 'build fedora dev image'
         run: buildah unshare make branch_or_ref=master release_tag=master build_fedora
+
       - name: 'security scan image'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           make image_name=localhost/curl-dev-fedora:master scan
 
       - name: 'push images to github registry'
-        run: |
-          buildah push curl-dev-fedora:master "docker://ghcr.io/curl/curl-container/curl-dev-fedora:master"
+        run: buildah push curl-dev-fedora:master "docker://ghcr.io/curl/curl-container/curl-dev-fedora:master"
 
       - name: 'sign image with a key'
         env:

--- a/.github/workflows/build_master_dev.yml
+++ b/.github/workflows/build_master_dev.yml
@@ -35,6 +35,7 @@ jobs:
         run: |
           echo "${DOCKER_HUB_TOKEN}" | podman login -u "${DOCKER_HUB_USER}" --password-stdin docker.io
           echo "${DOCKER_HUB_TOKEN}" | docker login -u "${DOCKER_HUB_USER}" --password-stdin
+
       - name: 'login quay.io'
         env:
           QUAY_USER: '${{ secrets.QUAY_USER }}'
@@ -42,53 +43,67 @@ jobs:
         run: |
           echo "${QUAY_TOKEN}" | podman login -u "${QUAY_USER}" --password-stdin quay.io
           echo "${QUAY_TOKEN}" | docker login -u "${QUAY_USER}" --password-stdin quay.io
+
       - name: 'install dev deps'
         run: |
           sudo rm -f /etc/apt/sources.list.d/{azure-cli.sources,microsoft-prod.list,ondrej-ubuntu-php-noble.sources}
           sudo apt-get -o Dpkg::Use-Pty=0 update
           sudo apt-get -o Dpkg::Use-Pty=0 install \
             qemu-user-static buildah less git make podman clamav clamav-freshclam
+
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           persist-credentials: false
           ref: 'main'
+
       - name: 'build debian dev image'
         run: buildah unshare make branch_or_ref=master release_tag=master build_debian
+
       - name: 'install scan prereqs'
         run: /home/linuxbrew/.linuxbrew/bin/brew install grype trivy
+
       - name: 'security scan image'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           make image_name=localhost/curl-dev-debian:master scan
+
       - name: 'push images to github registry'
         run: |
           buildah push curl-dev-debian:master "docker://ghcr.io/curl/curl-container/curl-dev-debian:master"
+
       - name: 'install Cosign'
         uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
+
       - name: 'sign image with a key'
         env:
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
           COSIGN_PRIVATE_KEY: '${{ secrets.COSIGN_PRIVATE_KEY }}'
         run: |
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl-dev-debian:master
+
       - name: 'verify image with public key'
         run: |
           cosign verify --key cosign.pub ghcr.io/curl/curl-container/curl-dev-debian:master
+
       - name: 'build fedora dev image'
         run: buildah unshare make branch_or_ref=master release_tag=master build_fedora
+
       - name: 'security scan image'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           make image_name=localhost/curl-dev-fedora:master scan
+
       - name: 'push images to github registry'
         run: |
           buildah push curl-dev-fedora:master "docker://ghcr.io/curl/curl-container/curl-dev-fedora:master"
+
       - name: 'sign image with a key'
         env:
           COSIGN_PASSWORD: '${{ secrets.COSIGN_PASSWORD }}'
           COSIGN_PRIVATE_KEY: '${{ secrets.COSIGN_PRIVATE_KEY }}'
         run: |
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl-dev-fedora:master
+
       - name: 'verify image with public key'
         run: |
           cosign verify --key cosign.pub ghcr.io/curl/curl-container/curl-dev-fedora:master

--- a/.github/workflows/build_master_multi.yml
+++ b/.github/workflows/build_master_multi.yml
@@ -51,6 +51,9 @@ jobs:
           sudo apt-get -o Dpkg::Use-Pty=0 install \
             qemu-user-static buildah less git make podman clamav clamav-freshclam
 
+      - name: 'install prereqs'
+        run: /home/linuxbrew/.linuxbrew/bin/brew install cosign grype trivy
+
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           persist-credentials: false
@@ -62,9 +65,6 @@ jobs:
       - name: 'test image'
         run: buildah unshare make dist_name=localhost/curl-multi release_tag=master test
 
-      - name: 'install scan prereqs'
-        run: /home/linuxbrew/.linuxbrew/bin/brew install grype trivy
-
       - name: 'security scan image'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
@@ -75,18 +75,17 @@ jobs:
           buildah manifest push --all --format v2s2 localhost/curl-base-multi:master "docker://ghcr.io/curl/curl-container/curl-base-multi:master"
           buildah manifest push --all --format v2s2 localhost/curl-multi:master "docker://ghcr.io/curl/curl-container/curl-multi:master"
 
-      - name: 'install Cosign'
-        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
-
       - name: 'sign image with a key'
         env:
           COSIGN_PASSWORD: '${{ secrets.COSIGN_PASSWORD }}'
           COSIGN_PRIVATE_KEY: '${{ secrets.COSIGN_PRIVATE_KEY }}'
         run: |
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl-multi:master
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl-base-multi:master
 
       - name: 'verify image with public key'
         run: |
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           cosign verify --key cosign.pub ghcr.io/curl/curl-container/curl-multi:master
           cosign verify --key cosign.pub ghcr.io/curl/curl-container/curl-base-multi:master

--- a/.github/workflows/build_master_multi.yml
+++ b/.github/workflows/build_master_multi.yml
@@ -31,6 +31,11 @@ jobs:
       - name: 'install prereqs'
         run: /home/linuxbrew/.linuxbrew/bin/brew install cosign grype trivy
 
+      - name: 'versions'
+        run: |
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+          podman --version; docker --version; cosign version
+
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           persist-credentials: false

--- a/.github/workflows/build_master_multi.yml
+++ b/.github/workflows/build_master_multi.yml
@@ -72,8 +72,8 @@ jobs:
 
       - name: 'push multi images to github registry'
         run: |
+          buildah manifest push --all --format v2s2 localhost/curl-multi:master      "docker://ghcr.io/curl/curl-container/curl-multi:master"
           buildah manifest push --all --format v2s2 localhost/curl-base-multi:master "docker://ghcr.io/curl/curl-container/curl-base-multi:master"
-          buildah manifest push --all --format v2s2 localhost/curl-multi:master "docker://ghcr.io/curl/curl-container/curl-multi:master"
 
       - name: 'sign image with a key'
         env:

--- a/.github/workflows/build_master_multi.yml
+++ b/.github/workflows/build_master_multi.yml
@@ -67,6 +67,9 @@ jobs:
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl-multi:master
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl-base-multi:master
 
+      - name: 'logout (ghcr.io)'
+        run: podman logout "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
+
       - name: 'verify image with public key'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"

--- a/.github/workflows/build_master_multi.yml
+++ b/.github/workflows/build_master_multi.yml
@@ -45,7 +45,7 @@ jobs:
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           make image_name=localhost/curl-multi:master scan
 
-      - name: 'login ghcr.io'
+      - name: 'login (ghcr.io)'
         env:
           REGISTRY_USER: '${{ github.actor }}'
           REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/build_master_multi.yml
+++ b/.github/workflows/build_master_multi.yml
@@ -51,7 +51,7 @@ jobs:
         env:
           REGISTRY_USER: '${{ github.actor }}'
           REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-        run: echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
+        run: echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin ghcr.io/"${GITHUB_REPOSITORY_OWNER}"
 
       - name: 'push multi images to github registry'
         run: |
@@ -68,7 +68,7 @@ jobs:
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl-base-multi:master
 
       - name: 'logout (ghcr.io)'
-        run: podman logout "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
+        run: podman logout ghcr.io/"${GITHUB_REPOSITORY_OWNER}"
 
       - name: 'verify image with public key'
         run: |

--- a/.github/workflows/build_master_multi.yml
+++ b/.github/workflows/build_master_multi.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: 'login ghcr.io'
         env:
-          REGISTRY_USER: '${{ github.repository_owner }}'
+          REGISTRY_USER: '${{ github.actor }}'
           REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         run: |
           echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"

--- a/.github/workflows/build_master_multi.yml
+++ b/.github/workflows/build_master_multi.yml
@@ -27,7 +27,6 @@ jobs:
           REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         run: |
           echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
-          echo "${REGISTRY_TOKEN}" | docker login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
 
       - name: 'login docker hub'
         env:

--- a/.github/workflows/build_master_multi.yml
+++ b/.github/workflows/build_master_multi.yml
@@ -22,11 +22,12 @@ jobs:
       packages: write  # To create/update container on ghcr.io
     steps:
       - name: 'login ghcr.io'
-        uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7
-        with:
-          username: '${{ github.actor }}'
-          password: '${{ secrets.GITHUB_TOKEN }}'
-          registry: 'ghcr.io/${{ github.repository_owner }}'
+        env:
+          REGISTRY_USER: '${{ github.actor }}'
+          REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+        run: |
+          echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
+          echo "${REGISTRY_TOKEN}" | docker login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
 
       - name: 'login docker hub'
         env:

--- a/.github/workflows/build_master_multi.yml
+++ b/.github/workflows/build_master_multi.yml
@@ -55,8 +55,8 @@ jobs:
 
       - name: 'push multi images to github registry'
         run: |
-          buildah manifest push --all --format v2s2 localhost/curl-multi:master      "docker://ghcr.io/curl/curl-container/curl-multi:master"
-          buildah manifest push --all --format v2s2 localhost/curl-base-multi:master "docker://ghcr.io/curl/curl-container/curl-base-multi:master"
+          buildah manifest push --all --format v2s2 localhost/curl-multi:master      "docker://ghcr.io/${GITHUB_REPOSITORY}/curl-multi:master"
+          buildah manifest push --all --format v2s2 localhost/curl-base-multi:master "docker://ghcr.io/${GITHUB_REPOSITORY}/curl-base-multi:master"
 
       - name: 'sign image with a key'
         env:
@@ -64,8 +64,8 @@ jobs:
           COSIGN_PRIVATE_KEY: '${{ secrets.COSIGN_PRIVATE_KEY }}'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-          echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl-multi:master
-          echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl-base-multi:master
+          echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/${GITHUB_REPOSITORY}/curl-multi:master
+          echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/${GITHUB_REPOSITORY}/curl-base-multi:master
 
       - name: 'logout (ghcr.io)'
         run: podman logout ghcr.io/"${GITHUB_REPOSITORY_OWNER}"
@@ -73,5 +73,5 @@ jobs:
       - name: 'verify image with public key'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-          cosign verify --key cosign.pub ghcr.io/curl/curl-container/curl-multi:master
-          cosign verify --key cosign.pub ghcr.io/curl/curl-container/curl-base-multi:master
+          cosign verify --key cosign.pub ghcr.io/${GITHUB_REPOSITORY}/curl-multi:master
+          cosign verify --key cosign.pub ghcr.io/${GITHUB_REPOSITORY}/curl-base-multi:master

--- a/.github/workflows/build_master_multi.yml
+++ b/.github/workflows/build_master_multi.yml
@@ -55,8 +55,8 @@ jobs:
 
       - name: 'push multi images to github registry'
         run: |
-          buildah manifest push --all --format v2s2 localhost/curl-multi:master      "docker://ghcr.io/${GITHUB_REPOSITORY}/curl-multi:master"
-          buildah manifest push --all --format v2s2 localhost/curl-base-multi:master "docker://ghcr.io/${GITHUB_REPOSITORY}/curl-base-multi:master"
+          buildah manifest push --all --format v2s2 localhost/curl-multi:master      docker://ghcr.io/"${GITHUB_REPOSITORY}"/curl-multi:master
+          buildah manifest push --all --format v2s2 localhost/curl-base-multi:master docker://ghcr.io/"${GITHUB_REPOSITORY}"/curl-base-multi:master
 
       - name: 'sign image with a key'
         env:
@@ -64,8 +64,8 @@ jobs:
           COSIGN_PRIVATE_KEY: '${{ secrets.COSIGN_PRIVATE_KEY }}'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-          echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/${GITHUB_REPOSITORY}/curl-multi:master
-          echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/${GITHUB_REPOSITORY}/curl-base-multi:master
+          echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/"${GITHUB_REPOSITORY}"/curl-multi:master
+          echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/"${GITHUB_REPOSITORY}"/curl-base-multi:master
 
       - name: 'logout (ghcr.io)'
         run: podman logout ghcr.io/"${GITHUB_REPOSITORY_OWNER}"
@@ -73,5 +73,5 @@ jobs:
       - name: 'verify image with public key'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-          cosign verify --key cosign.pub ghcr.io/${GITHUB_REPOSITORY}/curl-multi:master
-          cosign verify --key cosign.pub ghcr.io/${GITHUB_REPOSITORY}/curl-base-multi:master
+          cosign verify --key cosign.pub ghcr.io/"${GITHUB_REPOSITORY}"/curl-multi:master
+          cosign verify --key cosign.pub ghcr.io/"${GITHUB_REPOSITORY}"/curl-base-multi:master

--- a/.github/workflows/build_master_multi.yml
+++ b/.github/workflows/build_master_multi.yml
@@ -27,6 +27,7 @@ jobs:
           username: '${{ github.actor }}'
           password: '${{ secrets.GITHUB_TOKEN }}'
           registry: 'ghcr.io/${{ github.repository_owner }}'
+
       - name: 'login docker hub'
         env:
           DOCKER_HUB_USER: '${{ secrets.DOCKER_HUB_USER }}'
@@ -34,6 +35,7 @@ jobs:
         run: |
           echo "${DOCKER_HUB_TOKEN}" | podman login -u "${DOCKER_HUB_USER}" --password-stdin docker.io
           echo "${DOCKER_HUB_TOKEN}" | docker login -u "${DOCKER_HUB_USER}" --password-stdin
+
       - name: 'login quay.io'
         env:
           QUAY_USER: '${{ secrets.QUAY_USER }}'
@@ -41,32 +43,41 @@ jobs:
         run: |
           echo "${QUAY_TOKEN}" | podman login -u "${QUAY_USER}" --password-stdin quay.io
           echo "${QUAY_TOKEN}" | docker login -u "${QUAY_USER}" --password-stdin quay.io
+
       - name: 'install dev deps'
         run: |
           sudo rm -f /etc/apt/sources.list.d/{azure-cli.sources,microsoft-prod.list,ondrej-ubuntu-php-noble.sources}
           sudo apt-get -o Dpkg::Use-Pty=0 update
           sudo apt-get -o Dpkg::Use-Pty=0 install \
             qemu-user-static buildah less git make podman clamav clamav-freshclam
+
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           persist-credentials: false
           ref: 'main'
+
       - name: 'build multi image'
         run: buildah unshare make branch_or_ref=master release_tag=master multibuild
+
       - name: 'test image'
         run: buildah unshare make dist_name=localhost/curl-multi release_tag=master test
+
       - name: 'install scan prereqs'
         run: /home/linuxbrew/.linuxbrew/bin/brew install grype trivy
+
       - name: 'security scan image'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           make image_name=localhost/curl-multi:master scan
+
       - name: 'push multi images to github registry'
         run: |
           buildah manifest push --all --format v2s2 localhost/curl-base-multi:master "docker://ghcr.io/curl/curl-container/curl-base-multi:master"
           buildah manifest push --all --format v2s2 localhost/curl-multi:master "docker://ghcr.io/curl/curl-container/curl-multi:master"
+
       - name: 'install Cosign'
         uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
+
       - name: 'sign image with a key'
         env:
           COSIGN_PASSWORD: '${{ secrets.COSIGN_PASSWORD }}'
@@ -74,6 +85,7 @@ jobs:
         run: |
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl-multi:master
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl-base-multi:master
+
       - name: 'verify image with public key'
         run: |
           cosign verify --key cosign.pub ghcr.io/curl/curl-container/curl-multi:master

--- a/.github/workflows/build_master_multi.yml
+++ b/.github/workflows/build_master_multi.yml
@@ -38,10 +38,8 @@ jobs:
 
       - name: 'build multi image'
         run: buildah unshare make branch_or_ref=master release_tag=master multibuild
-
       - name: 'test image'
         run: buildah unshare make dist_name=localhost/curl-multi release_tag=master test
-
       - name: 'security scan image'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"

--- a/.github/workflows/build_master_multi.yml
+++ b/.github/workflows/build_master_multi.yml
@@ -38,8 +38,10 @@ jobs:
 
       - name: 'build multi image'
         run: buildah unshare make branch_or_ref=master release_tag=master multibuild
+
       - name: 'test image'
         run: buildah unshare make dist_name=localhost/curl-multi release_tag=master test
+
       - name: 'security scan image'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
@@ -49,8 +51,7 @@ jobs:
         env:
           REGISTRY_USER: '${{ github.actor }}'
           REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-        run: |
-          echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
+        run: echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
 
       - name: 'push multi images to github registry'
         run: |

--- a/.github/workflows/build_master_multi.yml
+++ b/.github/workflows/build_master_multi.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: 'login ghcr.io'
         env:
-          REGISTRY_USER: '${{ github.actor }}'
+          REGISTRY_USER: '${{ github.repository_owner }}'
           REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         run: |
           echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"

--- a/.github/workflows/build_master_multi.yml
+++ b/.github/workflows/build_master_multi.yml
@@ -28,22 +28,6 @@ jobs:
         run: |
           echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
 
-      - name: 'login docker hub'
-        env:
-          DOCKER_HUB_USER: '${{ secrets.DOCKER_HUB_USER }}'
-          DOCKER_HUB_TOKEN: '${{ secrets.DOCKER_HUB_TOKEN }}'
-        run: |
-          echo "${DOCKER_HUB_TOKEN}" | podman login -u "${DOCKER_HUB_USER}" --password-stdin docker.io
-          echo "${DOCKER_HUB_TOKEN}" | docker login -u "${DOCKER_HUB_USER}" --password-stdin
-
-      - name: 'login quay.io'
-        env:
-          QUAY_USER: '${{ secrets.QUAY_USER }}'
-          QUAY_TOKEN: '${{ secrets.QUAY_TOKEN }}'
-        run: |
-          echo "${QUAY_TOKEN}" | podman login -u "${QUAY_USER}" --password-stdin quay.io
-          echo "${QUAY_TOKEN}" | docker login -u "${QUAY_USER}" --password-stdin quay.io
-
       - name: 'install dev deps'
         run: |
           sudo rm -f /etc/apt/sources.list.d/{azure-cli.sources,microsoft-prod.list,ondrej-ubuntu-php-noble.sources}

--- a/.github/workflows/build_master_multi.yml
+++ b/.github/workflows/build_master_multi.yml
@@ -21,13 +21,6 @@ jobs:
     permissions:
       packages: write  # To create/update container on ghcr.io
     steps:
-      - name: 'login ghcr.io'
-        env:
-          REGISTRY_USER: '${{ github.actor }}'
-          REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-        run: |
-          echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
-
       - name: 'install dev deps'
         run: |
           sudo rm -f /etc/apt/sources.list.d/{azure-cli.sources,microsoft-prod.list,ondrej-ubuntu-php-noble.sources}
@@ -53,6 +46,13 @@ jobs:
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           make image_name=localhost/curl-multi:master scan
+
+      - name: 'login ghcr.io'
+        env:
+          REGISTRY_USER: '${{ github.actor }}'
+          REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+        run: |
+          echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
 
       - name: 'push multi images to github registry'
         run: |


### PR DESCRIPTION
Complete TODOs/ideas remaining after #94:

- display/log versions of podman, docker, cosign.
- logout from container registries.
- delete unused logins.
- move logins closer to push & sign. To avoid being logged-in while
  building.
- replace `redhat-actions/podman-login` action with `podman login`
  command for `ghcr.io` logins.
  They do the same; local command invocation is a bit more secure,
  the Action logs out automatically.
  It allows dropping this Action dependency and simplify replicating
  the logic locally.
- replace `sigstore/cosign-installer` action with Linuxbrew. cosign
  is no longer pinned, with its upsides and downsides.
  It allows dropping this Action dependency and simplify replicating
  the logic locally.
- add newlines between job steps. To fix syntax highlighting in some
  editors (mcedit), also possibly making it easier to read.
- replace hard-wired `curl/curl-container` with `GITHUB_REPOSITORY` env.
  To match `GITHUB_REPOSITORY_OWNER` already used on login.
- say the registry domain in step descriptions.
- minor formatting, quote-style, and other sync-ups between workflows,
  jobs, steps.

Also:

- build_latest_release_multi: do `cosign verify` for `docker.io` last,
  to not block other steps due to flaky: `Error: no signatures found`.
  E.g.: https://github.com/curl/curl-container/actions/runs/19098817652/job/54591850168
  (latest cosign installed via `sigstore/cosign-installer` v4.0.0 → cosign v3.02)
- build_latest_release_multi: use `-d` to debug `cosign verify` flaky
  failures with `docker.io`. Make sure to logout beforehand, just in
  case.

Follow-up to 818d601d4f768372f790239ad8c22582d1c1d28c #94

---

https://github.com/curl/curl-container/pull/102/files?w=1

- [x] delete Settings / Actions / General exceptions for GitHub repo.
- [x] maybe replace ghcr.io user `github.actor` with `github.repository_owner` (=`curl`)? GH token works with both. [WORKS, but no advantages ATM, with a chance of breaking things, so SKIP.] [UPDATE: switched to repo-owner.]
- [x] think of a way to test the other steps in a PR (perhaps in a PR fork it'd work with the secrets set). → #112 (for the builds. To test the push/sign/verify cycle, I have no idea, it'd most likely need a dedicated test container online, ideally with test credentials.)
- [x] is it necessay to login with both docker/podman? [YES: cosign recognizes the docker auth config, but not the podman one, meaning that's always needed.]
- [x] is `localhost` required in `imageID` in some of the `buildah manifest push` command-lines? [Seems optional, both seem good, and for consistenty I try using localhost where missing]
- [ ] perhaps push and sign in a single step?
- [ ] Fix this?:
```
> Run echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl-dev-debian:master
WARNING: Image reference ghcr.io/curl/curl-container/curl-dev-debian:master uses a tag, not a digest, to identify the image to sign.
    This can lead you to sign a different image than the intended one. Please use a
    digest (example.com/ubuntu@sha256:abc123...) rather than tag
    (example.com/ubuntu:latest) for the input to cosign. The ability to refer to
    images by tag will be removed in a future release.

Signing artifact...
```
Ref: https://github.com/curl/curl-container/actions/runs/20120515214/job/57739492278
