### PR TITLE
GHA: re-apply light changes from reverted #102

### DIFF
--- a/.github/workflows/build_ci_multi.yml
+++ b/.github/workflows/build_ci_multi.yml
@@ -41,10 +41,9 @@ jobs:
         env:
           REGISTRY_USER: '${{ github.repository_owner }}'
           REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-          IMAGE_REGISTRY: 'ghcr.io/${{ github.repository_owner }}'
         run: |
-          echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "${IMAGE_REGISTRY}"
-          echo "${REGISTRY_TOKEN}" | docker login -u "${REGISTRY_USER}" --password-stdin "${IMAGE_REGISTRY}"
+          echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin ghcr.io/"${GITHUB_REPOSITORY_OWNER}"
+          echo "${REGISTRY_TOKEN}" | docker login -u "${REGISTRY_USER}" --password-stdin ghcr.io/"${GITHUB_REPOSITORY_OWNER}"
 
   verify_secrets_registries:
     name: 'Verify credentials (docker.io, quay.io)'

--- a/.github/workflows/build_ci_multi.yml
+++ b/.github/workflows/build_ci_multi.yml
@@ -34,8 +34,8 @@ jobs:
           REGISTRY_USER: '${{ github.actor }}'
           REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         run: |
-          echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
-          echo "${REGISTRY_TOKEN}" | docker login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
+          echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin ghcr.io/"${GITHUB_REPOSITORY_OWNER}"
+          echo "${REGISTRY_TOKEN}" | docker login -u "${REGISTRY_USER}" --password-stdin ghcr.io/"${GITHUB_REPOSITORY_OWNER}"
 
       - name: 'login (ghcr.io) as repo owner'
         env:

--- a/.github/workflows/build_ci_multi.yml
+++ b/.github/workflows/build_ci_multi.yml
@@ -17,6 +17,9 @@ jobs:
     name: 'Verify credentials'
     runs-on: 'ubuntu-latest'
     steps:
+      - name: 'versions'
+        run: podman --version; docker --version
+
       # upside: it logs out and aims to delete creds ~/.docker/config.json
       # downside: extra dependency, uses -p instead of --password-stdin
       - name: 'login (ghcr.io) as actor, via action'

--- a/.github/workflows/build_ci_multi.yml
+++ b/.github/workflows/build_ci_multi.yml
@@ -19,14 +19,14 @@ jobs:
     steps:
       # upside: it logs out and aims to delete creds ~/.docker/config.json
       # downside: extra dependency, uses -p instead of --password-stdin
-      - name: 'login ghcr.io (actor, via action)'
+      - name: 'login (ghcr.io) as actor, via action'
         uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7
         with:
           username: '${{ github.actor }}'
           password: '${{ secrets.GITHUB_TOKEN }}'
           registry: 'ghcr.io/${{ github.repository_owner }}'
 
-      - name: 'login ghcr.io (actor, direct)'
+      - name: 'login (ghcr.io) as actor'
         env:
           REGISTRY_USER: '${{ github.actor }}'
           REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
@@ -36,7 +36,7 @@ jobs:
           docker --version
           echo "${REGISTRY_TOKEN}" | docker login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
 
-      - name: 'login ghcr.io (repo owner, direct)'
+      - name: 'login (ghcr.io) as repo owner'
         env:
           REGISTRY_USER: '${{ github.repository_owner }}'
           REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
@@ -48,11 +48,11 @@ jobs:
           echo "${REGISTRY_TOKEN}" | docker login -u "${REGISTRY_USER}" --password-stdin "${IMAGE_REGISTRY}"
 
   verify_secrets_registries:
-    name: 'Verify credentials (docker hub, quay)'
+    name: 'Verify credentials (docker.io, quay.io)'
     runs-on: 'ubuntu-latest'
     if: ${{ github.secret_source == 'Actions' }}
     steps:
-      - name: 'login docker hub'
+      - name: 'login (docker.io)'
         env:
           DOCKER_HUB_USER: '${{ secrets.DOCKER_HUB_USER }}'
           DOCKER_HUB_TOKEN: '${{ secrets.DOCKER_HUB_TOKEN }}'
@@ -60,7 +60,7 @@ jobs:
           echo "${DOCKER_HUB_TOKEN}" | podman login -u "${DOCKER_HUB_USER}" --password-stdin docker.io
           echo "${DOCKER_HUB_TOKEN}" | docker login -u "${DOCKER_HUB_USER}" --password-stdin
 
-      - name: 'login quay.io'
+      - name: 'login (quay.io)'
         env:
           QUAY_USER: '${{ secrets.QUAY_USER }}'
           QUAY_TOKEN: '${{ secrets.QUAY_TOKEN }}'
@@ -82,12 +82,16 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           persist-credentials: false
+
       - name: 'build multi image'
         run: buildah unshare make branch_or_ref=master release_tag=master multibuild
+
       - name: 'test image'
         run: buildah unshare make dist_name=localhost/curl-multi release_tag=master test
+
       - name: 'install scan prereqs'
         run: /home/linuxbrew/.linuxbrew/bin/brew install grype trivy
+
       - name: 'security scan image'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"

--- a/.github/workflows/build_ci_multi.yml
+++ b/.github/workflows/build_ci_multi.yml
@@ -34,9 +34,7 @@ jobs:
           REGISTRY_USER: '${{ github.actor }}'
           REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         run: |
-          podman --version
           echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
-          docker --version
           echo "${REGISTRY_TOKEN}" | docker login -u "${REGISTRY_USER}" --password-stdin "ghcr.io/${GITHUB_REPOSITORY_OWNER}"
 
       - name: 'login (ghcr.io) as repo owner'
@@ -45,9 +43,7 @@ jobs:
           REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
           IMAGE_REGISTRY: 'ghcr.io/${{ github.repository_owner }}'
         run: |
-          podman --version
           echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin "${IMAGE_REGISTRY}"
-          docker --version
           echo "${REGISTRY_TOKEN}" | docker login -u "${REGISTRY_USER}" --password-stdin "${IMAGE_REGISTRY}"
 
   verify_secrets_registries:

--- a/.github/workflows/build_latest_release_multi.yml
+++ b/.github/workflows/build_latest_release_multi.yml
@@ -18,36 +18,41 @@ jobs:
     permissions:
       packages: write  # To create/update container on ghcr.io
     steps:
-      - name: 'login ghcr.io'
+      - name: 'login (ghcr.io)'
         uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7
         with:
           username: '${{ github.actor }}'
           password: '${{ secrets.GITHUB_TOKEN }}'
           registry: 'ghcr.io/${{ github.repository_owner }}'
-      - name: 'login docker hub'
+
+      - name: 'login (docker.io)'
         env:
           DOCKER_HUB_USER: '${{ secrets.DOCKER_HUB_USER }}'
           DOCKER_HUB_TOKEN: '${{ secrets.DOCKER_HUB_TOKEN }}'
         run: |
           echo "${DOCKER_HUB_TOKEN}" | podman login -u "${DOCKER_HUB_USER}" --password-stdin docker.io
           echo "${DOCKER_HUB_TOKEN}" | docker login -u "${DOCKER_HUB_USER}" --password-stdin
-      - name: 'login quay.io'
+
+      - name: 'login (quay.io)'
         env:
           QUAY_USER: '${{ secrets.QUAY_USER }}'
           QUAY_TOKEN: '${{ secrets.QUAY_TOKEN }}'
         run: |
           echo "${QUAY_TOKEN}" | podman login -u "${QUAY_USER}" --password-stdin quay.io
           echo "${QUAY_TOKEN}" | docker login -u "${QUAY_USER}" --password-stdin quay.io
+
       - name: 'install dev deps'
         run: |
           sudo rm -f /etc/apt/sources.list.d/{azure-cli.sources,microsoft-prod.list,ondrej-ubuntu-php-noble.sources}
           sudo apt-get -o Dpkg::Use-Pty=0 update
           sudo apt-get -o Dpkg::Use-Pty=0 install \
             qemu-user-static buildah less git make podman clamav clamav-freshclam
+
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           persist-credentials: false
           tag_name: ${{ github.ref }}
+
       - name: 'set env vars'
         run: |
           release_tag_redirect=$(curl -s https://github.com/curl/curl/releases/latest -w'%{redirect_url}\n' -o /dev/null)
@@ -56,40 +61,50 @@ jobs:
           rel=${latest_release_ref:5}
           release_image_tag="${rel//_/.}"
           echo "REL=$release_image_tag" >> "$GITHUB_ENV"
+
       - name: 'build multi image'
         run: buildah unshare make branch_or_ref="$TAG_REF" release_tag="$REL" multibuild
+
       - name: 'test image'
         run: buildah unshare make dist_name=localhost/curl-multi release_tag="$REL" test
+
       - name: 'install scan prereqs'
         run: /home/linuxbrew/.linuxbrew/bin/brew install grype trivy
+
       - name: 'security scan image'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           make image_name=localhost/curl-multi:"$REL" scan
-      - name: 'push images to github registry'
+
+      - name: 'push images (ghcr.io)'
         run: |
           buildah manifest push --format v2s2 --all curl-multi:"$REL" docker://ghcr.io/curl/curl-container/curl-multi:"$REL"
           buildah manifest push --format v2s2 --all curl-base-multi:"$REL" docker://ghcr.io/curl/curl-container/curl-base-multi:"$REL"
-      - name: 'install Cosign'
+
+      - name: 'install cosign'
         uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
-      - name: 'sign images with sigstore key'
+
+      - name: 'sign images with sigstore key (ghcr.io)'
         env:
           COSIGN_PASSWORD: '${{ secrets.COSIGN_PASSWORD }}'
           COSIGN_PRIVATE_KEY: '${{ secrets.COSIGN_PRIVATE_KEY }}'
         run: |
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl-multi:"$REL"
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl-base-multi:"$REL"
-      - name: 'verify image with public key'
+
+      - name: 'verify images with public key (ghcr.io)'
         run: |
           cosign verify --key cosign.pub ghcr.io/curl/curl-container/curl-multi:"$REL"
           cosign verify --key cosign.pub ghcr.io/curl/curl-container/curl-base-multi:"$REL"
-      - name: 'push release to docker hub'
+
+      - name: 'push images (docker.io)'
         run: |
           buildah manifest push --format v2s2 --all localhost/curl-multi:"$REL" docker://docker.io/curlimages/curl:"$REL"
           buildah manifest push --format v2s2 --all localhost/curl-multi:"$REL" docker://docker.io/curlimages/curl:latest
           buildah manifest push --format v2s2 --all localhost/curl-base-multi:"$REL" docker://docker.io/curlimages/curl-base:"$REL"
           buildah manifest push --format v2s2 --all localhost/curl-base-multi:"$REL" docker://docker.io/curlimages/curl-base:latest
-      - name: 'sign images with a sigstore key'
+
+      - name: 'sign images with sigstore key (docker.io)'
         env:
           COSIGN_PASSWORD: '${{ secrets.COSIGN_PASSWORD }}'
           COSIGN_PRIVATE_KEY: '${{ secrets.COSIGN_PRIVATE_KEY }}'
@@ -98,13 +113,15 @@ jobs:
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin docker.io/curlimages/curl:latest
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin docker.io/curlimages/curl-base:"$REL"
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin docker.io/curlimages/curl-base:latest
-      - name: 'push release to quay.io'
+
+      - name: 'push images (quay.io)'
         run: |
           buildah manifest push --format v2s2 --all localhost/curl-multi:"$REL" docker://quay.io/curl/curl:"$REL"
           buildah manifest push --format v2s2 --all localhost/curl-multi:"$REL" docker://quay.io/curl/curl:latest
           buildah manifest push --format v2s2 --all localhost/curl-base-multi:"$REL" docker://quay.io/curl/curl-base:"$REL"
           buildah manifest push --format v2s2 --all localhost/curl-base-multi:"$REL" docker://quay.io/curl/curl-base:latest
-      - name: 'sign images with a sigstore key'
+
+      - name: 'sign images with sigstore key (quay.io)'
         env:
           COSIGN_PASSWORD: '${{ secrets.COSIGN_PASSWORD }}'
           COSIGN_PRIVATE_KEY: '${{ secrets.COSIGN_PRIVATE_KEY }}'
@@ -113,13 +130,15 @@ jobs:
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin quay.io/curl/curl:latest
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin quay.io/curl/curl-base:"$REL"
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin quay.io/curl/curl-base:latest
-      - name: 'verify docker image with public key'
+
+      - name: 'verify images with public key (docker.io)'
         run: |
           cosign verify --key cosign.pub docker.io/curlimages/curl:"$REL"
           cosign verify --key cosign.pub docker.io/curlimages/curl:latest
           cosign verify --key cosign.pub docker.io/curlimages/curl-base:"$REL"
           cosign verify --key cosign.pub docker.io/curlimages/curl-base:latest
-      - name: 'verify quay image with public key'
+
+      - name: 'verify images with public key (quay.io)'
         run: |
           cosign verify --key cosign.pub quay.io/curl/curl:"$REL"
           cosign verify --key cosign.pub quay.io/curl/curl:latest

--- a/.github/workflows/build_latest_release_multi.yml
+++ b/.github/workflows/build_latest_release_multi.yml
@@ -78,8 +78,8 @@ jobs:
 
       - name: 'push images (ghcr.io)'
         run: |
-          buildah manifest push --format v2s2 --all curl-multi:"$REL"      docker://ghcr.io/curl/curl-container/curl-multi:"$REL"
-          buildah manifest push --format v2s2 --all curl-base-multi:"$REL" docker://ghcr.io/curl/curl-container/curl-base-multi:"$REL"
+          buildah manifest push --format v2s2 --all curl-multi:"$REL"      docker://ghcr.io/"${GITHUB_REPOSITORY}"/curl-multi:"$REL"
+          buildah manifest push --format v2s2 --all curl-base-multi:"$REL" docker://ghcr.io/"${GITHUB_REPOSITORY}"/curl-base-multi:"$REL"
 
       - name: 'install cosign'
         uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
@@ -89,13 +89,13 @@ jobs:
           COSIGN_PASSWORD: '${{ secrets.COSIGN_PASSWORD }}'
           COSIGN_PRIVATE_KEY: '${{ secrets.COSIGN_PRIVATE_KEY }}'
         run: |
-          echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl-multi:"$REL"
-          echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl-base-multi:"$REL"
+          echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/"${GITHUB_REPOSITORY}"/curl-multi:"$REL"
+          echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/"${GITHUB_REPOSITORY}"/curl-base-multi:"$REL"
 
       - name: 'verify images with public key (ghcr.io)'
         run: |
-          cosign verify --key cosign.pub ghcr.io/curl/curl-container/curl-multi:"$REL"
-          cosign verify --key cosign.pub ghcr.io/curl/curl-container/curl-base-multi:"$REL"
+          cosign verify --key cosign.pub ghcr.io/"${GITHUB_REPOSITORY}"/curl-multi:"$REL"
+          cosign verify --key cosign.pub ghcr.io/"${GITHUB_REPOSITORY}"/curl-base-multi:"$REL"
 
       - name: 'push images (docker.io)'
         run: |

--- a/.github/workflows/build_latest_release_multi.yml
+++ b/.github/workflows/build_latest_release_multi.yml
@@ -139,6 +139,7 @@ jobs:
           cosign verify --key cosign.pub quay.io/curl/curl-base:latest
 
       - name: 'verify images with public key (docker.io)'
+        # Seen flaky with 'Error: no signatures found' (with cosign v3.0.2). Do it last to let other steps finish.
         run: |
           cosign verify --key cosign.pub docker.io/curlimages/curl:"$REL"
           cosign verify --key cosign.pub docker.io/curlimages/curl:latest

--- a/.github/workflows/build_latest_release_multi.yml
+++ b/.github/workflows/build_latest_release_multi.yml
@@ -131,16 +131,16 @@ jobs:
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin quay.io/curl/curl-base:"$REL"
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin quay.io/curl/curl-base:latest
 
-      - name: 'verify images with public key (docker.io)'
-        run: |
-          cosign verify --key cosign.pub docker.io/curlimages/curl:"$REL"
-          cosign verify --key cosign.pub docker.io/curlimages/curl:latest
-          cosign verify --key cosign.pub docker.io/curlimages/curl-base:"$REL"
-          cosign verify --key cosign.pub docker.io/curlimages/curl-base:latest
-
       - name: 'verify images with public key (quay.io)'
         run: |
           cosign verify --key cosign.pub quay.io/curl/curl:"$REL"
           cosign verify --key cosign.pub quay.io/curl/curl:latest
           cosign verify --key cosign.pub quay.io/curl/curl-base:"$REL"
           cosign verify --key cosign.pub quay.io/curl/curl-base:latest
+
+      - name: 'verify images with public key (docker.io)'
+        run: |
+          cosign verify --key cosign.pub docker.io/curlimages/curl:"$REL"
+          cosign verify --key cosign.pub docker.io/curlimages/curl:latest
+          cosign verify --key cosign.pub docker.io/curlimages/curl-base:"$REL"
+          cosign verify --key cosign.pub docker.io/curlimages/curl-base:latest

--- a/.github/workflows/build_latest_release_multi.yml
+++ b/.github/workflows/build_latest_release_multi.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: 'push images (ghcr.io)'
         run: |
-          buildah manifest push --format v2s2 --all curl-multi:"$REL" docker://ghcr.io/curl/curl-container/curl-multi:"$REL"
+          buildah manifest push --format v2s2 --all curl-multi:"$REL"      docker://ghcr.io/curl/curl-container/curl-multi:"$REL"
           buildah manifest push --format v2s2 --all curl-base-multi:"$REL" docker://ghcr.io/curl/curl-container/curl-base-multi:"$REL"
 
       - name: 'install cosign'
@@ -99,8 +99,8 @@ jobs:
 
       - name: 'push images (docker.io)'
         run: |
-          buildah manifest push --format v2s2 --all localhost/curl-multi:"$REL" docker://docker.io/curlimages/curl:"$REL"
-          buildah manifest push --format v2s2 --all localhost/curl-multi:"$REL" docker://docker.io/curlimages/curl:latest
+          buildah manifest push --format v2s2 --all localhost/curl-multi:"$REL"      docker://docker.io/curlimages/curl:"$REL"
+          buildah manifest push --format v2s2 --all localhost/curl-multi:"$REL"      docker://docker.io/curlimages/curl:latest
           buildah manifest push --format v2s2 --all localhost/curl-base-multi:"$REL" docker://docker.io/curlimages/curl-base:"$REL"
           buildah manifest push --format v2s2 --all localhost/curl-base-multi:"$REL" docker://docker.io/curlimages/curl-base:latest
 
@@ -116,8 +116,8 @@ jobs:
 
       - name: 'push images (quay.io)'
         run: |
-          buildah manifest push --format v2s2 --all localhost/curl-multi:"$REL" docker://quay.io/curl/curl:"$REL"
-          buildah manifest push --format v2s2 --all localhost/curl-multi:"$REL" docker://quay.io/curl/curl:latest
+          buildah manifest push --format v2s2 --all localhost/curl-multi:"$REL"      docker://quay.io/curl/curl:"$REL"
+          buildah manifest push --format v2s2 --all localhost/curl-multi:"$REL"      docker://quay.io/curl/curl:latest
           buildah manifest push --format v2s2 --all localhost/curl-base-multi:"$REL" docker://quay.io/curl/curl-base:"$REL"
           buildah manifest push --format v2s2 --all localhost/curl-base-multi:"$REL" docker://quay.io/curl/curl-base:latest
 

--- a/.github/workflows/build_master.yml
+++ b/.github/workflows/build_master.yml
@@ -21,54 +21,65 @@ jobs:
     permissions:
       packages: write  # To create/update container on ghcr.io
     steps:
-      - name: 'login ghcr.io'
+      - name: 'login (ghcr.io)'
         uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7
         with:
           username: '${{ github.actor }}'
           password: '${{ secrets.GITHUB_TOKEN }}'
           registry: 'ghcr.io/${{ github.repository_owner }}'
-      - name: 'login docker hub'
+
+      - name: 'login (docker.io)'
         env:
           DOCKER_HUB_USER: '${{ secrets.DOCKER_HUB_USER }}'
           DOCKER_HUB_TOKEN: '${{ secrets.DOCKER_HUB_TOKEN }}'
         run: |
           echo "${DOCKER_HUB_TOKEN}" | podman login -u "${DOCKER_HUB_USER}" --password-stdin docker.io
           echo "${DOCKER_HUB_TOKEN}" | docker login -u "${DOCKER_HUB_USER}" --password-stdin
-      - name: 'login quay.io'
+
+      - name: 'login (quay.io)'
         env:
           QUAY_USER: '${{ secrets.QUAY_USER }}'
           QUAY_TOKEN: '${{ secrets.QUAY_TOKEN }}'
         run: |
           echo "${QUAY_TOKEN}" | podman login -u "${QUAY_USER}" --password-stdin quay.io
           echo "${QUAY_TOKEN}" | docker login -u "${QUAY_USER}" --password-stdin quay.io
+
       - name: 'install dev deps'
         run: |
           sudo rm -f /etc/apt/sources.list.d/{azure-cli.sources,microsoft-prod.list,ondrej-ubuntu-php-noble.sources}
           sudo apt-get -o Dpkg::Use-Pty=0 update
           sudo apt-get -o Dpkg::Use-Pty=0 install \
             qemu-user-static buildah less git make podman clamav clamav-freshclam
+
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           persist-credentials: false
           ref: 'main'
+
       - name: 'build master images'
         run: buildah unshare make branch_or_ref=master release_tag=master build_ref_images
+
       - name: 'test image'
         run: buildah unshare make dist_name=localhost/curl release_tag=master test
+
       - name: 'install scan prereqs'
         run: /home/linuxbrew/.linuxbrew/bin/brew install grype trivy
+
       - name: 'security scan image'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           make image_name=localhost/curl:master scan
-      - name: 'push images to github registry'
+
+      - name: 'push images (ghcr.io)'
         run: |
           buildah push curl-dev:master "docker://ghcr.io/curl/curl-container/curl-dev:master"
           buildah push curl-base:master "docker://ghcr.io/curl/curl-container/curl-base:master"
           buildah push curl:master "docker://ghcr.io/curl/curl-container/curl:master"
-      - name: 'install Cosign'
+
+      - name: 'install cosign'
         uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
-      - name: 'sign image with a key'
+
+      - name: 'sign images with sigstore key (ghcr.io)'
         env:
           COSIGN_PASSWORD: '${{ secrets.COSIGN_PASSWORD }}'
           COSIGN_PRIVATE_KEY: '${{ secrets.COSIGN_PRIVATE_KEY }}'
@@ -76,7 +87,8 @@ jobs:
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl-dev:master
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl-base:master
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl:master
-      - name: 'verify image with public key'
+
+      - name: 'verify images with public key (ghcr.io)'
         run: |
           cosign verify --key cosign.pub ghcr.io/curl/curl-container/curl-dev:master
           cosign verify --key cosign.pub ghcr.io/curl/curl-container/curl-base:master

--- a/.github/workflows/build_master.yml
+++ b/.github/workflows/build_master.yml
@@ -72,9 +72,9 @@ jobs:
 
       - name: 'push images (ghcr.io)'
         run: |
-          buildah push curl-dev:master  "docker://ghcr.io/curl/curl-container/curl-dev:master"
-          buildah push curl-base:master "docker://ghcr.io/curl/curl-container/curl-base:master"
-          buildah push curl:master      "docker://ghcr.io/curl/curl-container/curl:master"
+          buildah push curl-dev:master  docker://ghcr.io/"${GITHUB_REPOSITORY}"/curl-dev:master
+          buildah push curl-base:master docker://ghcr.io/"${GITHUB_REPOSITORY}"/curl-base:master
+          buildah push curl:master      docker://ghcr.io/"${GITHUB_REPOSITORY}"/curl:master
 
       - name: 'install cosign'
         uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
@@ -84,12 +84,12 @@ jobs:
           COSIGN_PASSWORD: '${{ secrets.COSIGN_PASSWORD }}'
           COSIGN_PRIVATE_KEY: '${{ secrets.COSIGN_PRIVATE_KEY }}'
         run: |
-          echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl-dev:master
-          echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl-base:master
-          echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl:master
+          echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/"${GITHUB_REPOSITORY}"/curl-dev:master
+          echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/"${GITHUB_REPOSITORY}"/curl-base:master
+          echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/"${GITHUB_REPOSITORY}"/curl:master
 
       - name: 'verify images with public key (ghcr.io)'
         run: |
-          cosign verify --key cosign.pub ghcr.io/curl/curl-container/curl-dev:master
-          cosign verify --key cosign.pub ghcr.io/curl/curl-container/curl-base:master
-          cosign verify --key cosign.pub ghcr.io/curl/curl-container/curl:master
+          cosign verify --key cosign.pub ghcr.io/"${GITHUB_REPOSITORY}"/curl-dev:master
+          cosign verify --key cosign.pub ghcr.io/"${GITHUB_REPOSITORY}"/curl-base:master
+          cosign verify --key cosign.pub ghcr.io/"${GITHUB_REPOSITORY}"/curl:master

--- a/.github/workflows/build_master.yml
+++ b/.github/workflows/build_master.yml
@@ -72,9 +72,9 @@ jobs:
 
       - name: 'push images (ghcr.io)'
         run: |
-          buildah push curl-dev:master "docker://ghcr.io/curl/curl-container/curl-dev:master"
+          buildah push curl-dev:master  "docker://ghcr.io/curl/curl-container/curl-dev:master"
           buildah push curl-base:master "docker://ghcr.io/curl/curl-container/curl-base:master"
-          buildah push curl:master "docker://ghcr.io/curl/curl-container/curl:master"
+          buildah push curl:master      "docker://ghcr.io/curl/curl-container/curl:master"
 
       - name: 'install cosign'
         uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0

--- a/.github/workflows/build_master_dev.yml
+++ b/.github/workflows/build_master_dev.yml
@@ -75,7 +75,7 @@ jobs:
       - name: 'install cosign'
         uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
 
-      - name: 'sign images with a key (ghcr.io)'
+      - name: 'sign images with sigstore key (ghcr.io)'
         env:
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
           COSIGN_PRIVATE_KEY: '${{ secrets.COSIGN_PRIVATE_KEY }}'

--- a/.github/workflows/build_master_dev.yml
+++ b/.github/workflows/build_master_dev.yml
@@ -22,73 +22,89 @@ jobs:
     permissions:
       packages: write  # To create/update container on ghcr.io
     steps:
-      - name: 'login ghcr.io'
+      - name: 'login (ghcr.io)'
         uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7
         with:
           username: '${{ github.actor }}'
           password: '${{ secrets.GITHUB_TOKEN }}'
           registry: 'ghcr.io/${{ github.repository_owner }}'
-      - name: 'login docker hub'
+
+      - name: 'login (docker.io)'
         env:
           DOCKER_HUB_USER: '${{ secrets.DOCKER_HUB_USER }}'
           DOCKER_HUB_TOKEN: '${{ secrets.DOCKER_HUB_TOKEN }}'
         run: |
           echo "${DOCKER_HUB_TOKEN}" | podman login -u "${DOCKER_HUB_USER}" --password-stdin docker.io
           echo "${DOCKER_HUB_TOKEN}" | docker login -u "${DOCKER_HUB_USER}" --password-stdin
-      - name: 'login quay.io'
+
+      - name: 'login (quay.io)'
         env:
           QUAY_USER: '${{ secrets.QUAY_USER }}'
           QUAY_TOKEN: '${{ secrets.QUAY_TOKEN }}'
         run: |
           echo "${QUAY_TOKEN}" | podman login -u "${QUAY_USER}" --password-stdin quay.io
           echo "${QUAY_TOKEN}" | docker login -u "${QUAY_USER}" --password-stdin quay.io
+
       - name: 'install dev deps'
         run: |
           sudo rm -f /etc/apt/sources.list.d/{azure-cli.sources,microsoft-prod.list,ondrej-ubuntu-php-noble.sources}
           sudo apt-get -o Dpkg::Use-Pty=0 update
           sudo apt-get -o Dpkg::Use-Pty=0 install \
             qemu-user-static buildah less git make podman clamav clamav-freshclam
+
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           persist-credentials: false
           ref: 'main'
+
       - name: 'build debian dev image'
         run: buildah unshare make branch_or_ref=master release_tag=master build_debian
+
       - name: 'install scan prereqs'
         run: /home/linuxbrew/.linuxbrew/bin/brew install grype trivy
+
       - name: 'security scan image'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           make image_name=localhost/curl-dev-debian:master scan
-      - name: 'push images to github registry'
+
+      - name: 'push images (ghcr.io)'
         run: |
           buildah push curl-dev-debian:master "docker://ghcr.io/curl/curl-container/curl-dev-debian:master"
-      - name: 'install Cosign'
+
+      - name: 'install cosign'
         uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
-      - name: 'sign image with a key'
+
+      - name: 'sign images with a key (ghcr.io)'
         env:
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
           COSIGN_PRIVATE_KEY: '${{ secrets.COSIGN_PRIVATE_KEY }}'
         run: |
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl-dev-debian:master
-      - name: 'verify image with public key'
+
+      - name: 'verify images with public key (ghcr.io)'
         run: |
           cosign verify --key cosign.pub ghcr.io/curl/curl-container/curl-dev-debian:master
+
       - name: 'build fedora dev image'
         run: buildah unshare make branch_or_ref=master release_tag=master build_fedora
+
       - name: 'security scan image'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           make image_name=localhost/curl-dev-fedora:master scan
-      - name: 'push images to github registry'
+
+      - name: 'push images (ghcr.io)'
         run: |
           buildah push curl-dev-fedora:master "docker://ghcr.io/curl/curl-container/curl-dev-fedora:master"
-      - name: 'sign image with a key'
+
+      - name: 'sign images with sigstore key (ghcr.io)'
         env:
           COSIGN_PASSWORD: '${{ secrets.COSIGN_PASSWORD }}'
           COSIGN_PRIVATE_KEY: '${{ secrets.COSIGN_PRIVATE_KEY }}'
         run: |
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl-dev-fedora:master
-      - name: 'verify image with public key'
+
+      - name: 'verify images with public key (ghcr.io)'
         run: |
           cosign verify --key cosign.pub ghcr.io/curl/curl-container/curl-dev-fedora:master

--- a/.github/workflows/build_master_dev.yml
+++ b/.github/workflows/build_master_dev.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: 'push images (ghcr.io)'
         run: |
-          buildah push curl-dev-debian:master "docker://ghcr.io/curl/curl-container/curl-dev-debian:master"
+          buildah push curl-dev-debian:master docker://ghcr.io/"${GITHUB_REPOSITORY}"/curl-dev-debian:master
 
       - name: 'install cosign'
         uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
@@ -80,11 +80,11 @@ jobs:
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
           COSIGN_PRIVATE_KEY: '${{ secrets.COSIGN_PRIVATE_KEY }}'
         run: |
-          echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl-dev-debian:master
+          echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/"${GITHUB_REPOSITORY}"/curl-dev-debian:master
 
       - name: 'verify images with public key (ghcr.io)'
         run: |
-          cosign verify --key cosign.pub ghcr.io/curl/curl-container/curl-dev-debian:master
+          cosign verify --key cosign.pub ghcr.io/"${GITHUB_REPOSITORY}"/curl-dev-debian:master
 
       - name: 'build fedora dev image'
         run: buildah unshare make branch_or_ref=master release_tag=master build_fedora
@@ -95,15 +95,15 @@ jobs:
           make image_name=localhost/curl-dev-fedora:master scan
 
       - name: 'push images (ghcr.io)'
-        run: buildah push curl-dev-fedora:master "docker://ghcr.io/curl/curl-container/curl-dev-fedora:master"
+        run: buildah push curl-dev-fedora:master docker://ghcr.io/"${GITHUB_REPOSITORY}"/curl-dev-fedora:master
 
       - name: 'sign images with sigstore key (ghcr.io)'
         env:
           COSIGN_PASSWORD: '${{ secrets.COSIGN_PASSWORD }}'
           COSIGN_PRIVATE_KEY: '${{ secrets.COSIGN_PRIVATE_KEY }}'
         run: |
-          echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl-dev-fedora:master
+          echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/"${GITHUB_REPOSITORY}"/curl-dev-fedora:master
 
       - name: 'verify images with public key (ghcr.io)'
         run: |
-          cosign verify --key cosign.pub ghcr.io/curl/curl-container/curl-dev-fedora:master
+          cosign verify --key cosign.pub ghcr.io/"${GITHUB_REPOSITORY}"/curl-dev-fedora:master

--- a/.github/workflows/build_master_dev.yml
+++ b/.github/workflows/build_master_dev.yml
@@ -95,8 +95,7 @@ jobs:
           make image_name=localhost/curl-dev-fedora:master scan
 
       - name: 'push images (ghcr.io)'
-        run: |
-          buildah push curl-dev-fedora:master "docker://ghcr.io/curl/curl-container/curl-dev-fedora:master"
+        run: buildah push curl-dev-fedora:master "docker://ghcr.io/curl/curl-container/curl-dev-fedora:master"
 
       - name: 'sign images with sigstore key (ghcr.io)'
         env:

--- a/.github/workflows/build_master_multi.yml
+++ b/.github/workflows/build_master_multi.yml
@@ -21,60 +21,72 @@ jobs:
     permissions:
       packages: write  # To create/update container on ghcr.io
     steps:
-      - name: 'login ghcr.io'
+      - name: 'login (ghcr.io)'
         uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7
         with:
           username: '${{ github.actor }}'
           password: '${{ secrets.GITHUB_TOKEN }}'
           registry: 'ghcr.io/${{ github.repository_owner }}'
-      - name: 'login docker hub'
+
+      - name: 'login (docker.io)'
         env:
           DOCKER_HUB_USER: '${{ secrets.DOCKER_HUB_USER }}'
           DOCKER_HUB_TOKEN: '${{ secrets.DOCKER_HUB_TOKEN }}'
         run: |
           echo "${DOCKER_HUB_TOKEN}" | podman login -u "${DOCKER_HUB_USER}" --password-stdin docker.io
           echo "${DOCKER_HUB_TOKEN}" | docker login -u "${DOCKER_HUB_USER}" --password-stdin
-      - name: 'login quay.io'
+
+      - name: 'login (quay.io)'
         env:
           QUAY_USER: '${{ secrets.QUAY_USER }}'
           QUAY_TOKEN: '${{ secrets.QUAY_TOKEN }}'
         run: |
           echo "${QUAY_TOKEN}" | podman login -u "${QUAY_USER}" --password-stdin quay.io
           echo "${QUAY_TOKEN}" | docker login -u "${QUAY_USER}" --password-stdin quay.io
+
       - name: 'install dev deps'
         run: |
           sudo rm -f /etc/apt/sources.list.d/{azure-cli.sources,microsoft-prod.list,ondrej-ubuntu-php-noble.sources}
           sudo apt-get -o Dpkg::Use-Pty=0 update
           sudo apt-get -o Dpkg::Use-Pty=0 install \
             qemu-user-static buildah less git make podman clamav clamav-freshclam
+
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           persist-credentials: false
           ref: 'main'
+
       - name: 'build multi image'
         run: buildah unshare make branch_or_ref=master release_tag=master multibuild
+
       - name: 'test image'
         run: buildah unshare make dist_name=localhost/curl-multi release_tag=master test
+
       - name: 'install scan prereqs'
         run: /home/linuxbrew/.linuxbrew/bin/brew install grype trivy
+
       - name: 'security scan image'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           make image_name=localhost/curl-multi:master scan
-      - name: 'push multi images to github registry'
+
+      - name: 'push multi images (ghcr.io)'
         run: |
           buildah manifest push --all --format v2s2 localhost/curl-base-multi:master "docker://ghcr.io/curl/curl-container/curl-base-multi:master"
           buildah manifest push --all --format v2s2 localhost/curl-multi:master "docker://ghcr.io/curl/curl-container/curl-multi:master"
-      - name: 'install Cosign'
+
+      - name: 'install cosign'
         uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
-      - name: 'sign image with a key'
+
+      - name: 'sign images with sigstore key (ghcr.io)'
         env:
           COSIGN_PASSWORD: '${{ secrets.COSIGN_PASSWORD }}'
           COSIGN_PRIVATE_KEY: '${{ secrets.COSIGN_PRIVATE_KEY }}'
         run: |
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl-multi:master
           echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl-base-multi:master
-      - name: 'verify image with public key'
+
+      - name: 'verify images with public key (ghcr.io)'
         run: |
           cosign verify --key cosign.pub ghcr.io/curl/curl-container/curl-multi:master
           cosign verify --key cosign.pub ghcr.io/curl/curl-container/curl-base-multi:master

--- a/.github/workflows/build_master_multi.yml
+++ b/.github/workflows/build_master_multi.yml
@@ -72,8 +72,8 @@ jobs:
 
       - name: 'push multi images (ghcr.io)'
         run: |
+          buildah manifest push --all --format v2s2 localhost/curl-multi:master      "docker://ghcr.io/curl/curl-container/curl-multi:master"
           buildah manifest push --all --format v2s2 localhost/curl-base-multi:master "docker://ghcr.io/curl/curl-container/curl-base-multi:master"
-          buildah manifest push --all --format v2s2 localhost/curl-multi:master "docker://ghcr.io/curl/curl-container/curl-multi:master"
 
       - name: 'install cosign'
         uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0

--- a/.github/workflows/build_master_multi.yml
+++ b/.github/workflows/build_master_multi.yml
@@ -72,8 +72,8 @@ jobs:
 
       - name: 'push multi images (ghcr.io)'
         run: |
-          buildah manifest push --all --format v2s2 localhost/curl-multi:master      "docker://ghcr.io/curl/curl-container/curl-multi:master"
-          buildah manifest push --all --format v2s2 localhost/curl-base-multi:master "docker://ghcr.io/curl/curl-container/curl-base-multi:master"
+          buildah manifest push --all --format v2s2 localhost/curl-multi:master      docker://ghcr.io/"${GITHUB_REPOSITORY}"/curl-multi:master
+          buildah manifest push --all --format v2s2 localhost/curl-base-multi:master docker://ghcr.io/"${GITHUB_REPOSITORY}"/curl-base-multi:master
 
       - name: 'install cosign'
         uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
@@ -83,10 +83,10 @@ jobs:
           COSIGN_PASSWORD: '${{ secrets.COSIGN_PASSWORD }}'
           COSIGN_PRIVATE_KEY: '${{ secrets.COSIGN_PRIVATE_KEY }}'
         run: |
-          echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl-multi:master
-          echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/curl/curl-container/curl-base-multi:master
+          echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/"${GITHUB_REPOSITORY}"/curl-multi:master
+          echo "${COSIGN_PRIVATE_KEY}" | cosign sign -y --key /dev/stdin ghcr.io/"${GITHUB_REPOSITORY}"/curl-base-multi:master
 
       - name: 'verify images with public key (ghcr.io)'
         run: |
-          cosign verify --key cosign.pub ghcr.io/curl/curl-container/curl-multi:master
-          cosign verify --key cosign.pub ghcr.io/curl/curl-container/curl-base-multi:master
+          cosign verify --key cosign.pub ghcr.io/"${GITHUB_REPOSITORY}"/curl-multi:master
+          cosign verify --key cosign.pub ghcr.io/"${GITHUB_REPOSITORY}"/curl-base-multi:master


### PR DESCRIPTION
- newlines, step names, vertical align, sort order, quotes.
- use `GITHUB_REPOSITORY` env.
- build_latest_release_multi: make docker.io verify the very last step.
- build_latest_release_multi: add docker.io verify comment.
- build_ci_multi: add version dump step.
- build_ci_multi: omit `IMAGE_REGISTRY` interim env.

Follow-up to 6831a9ea51d3a5b13999beea7c17d4303419693e
Follow-up to 214368a2ed2ed450be888d81f8480f428c9bad29 #102

---

https://github.com/curl/curl-container/pull/108/files?w=1
