### PR TITLE
GHA: try using repo owner, try login command to replace login Action

### DIFF
--- a/.github/workflows/build_master_dev.yml
+++ b/.github/workflows/build_master_dev.yml
@@ -23,11 +23,10 @@ jobs:
       packages: write  # To create/update container on ghcr.io
     steps:
       - name: 'login (ghcr.io)'
-        uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7
-        with:
-          username: '${{ github.actor }}'
-          password: '${{ secrets.GITHUB_TOKEN }}'
-          registry: 'ghcr.io/${{ github.repository_owner }}'
+        env:
+          REGISTRY_USER: '${{ github.actor }}'
+          REGISTRY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+        run: echo "${REGISTRY_TOKEN}" | podman login -u "${REGISTRY_USER}" --password-stdin ghcr.io/"${GITHUB_REPOSITORY_OWNER}"
 
       - name: 'login (docker.io)'
         env:
@@ -107,3 +106,6 @@ jobs:
       - name: 'verify images with public key (ghcr.io)'
         run: |
           cosign verify --key cosign.pub ghcr.io/"${GITHUB_REPOSITORY}"/curl-dev-fedora:master
+
+      - name: 'logout (ghcr.io)'
+        run: podman logout ghcr.io/"${GITHUB_REPOSITORY_OWNER}"

--- a/.github/workflows/build_master_multi.yml
+++ b/.github/workflows/build_master_multi.yml
@@ -24,7 +24,7 @@ jobs:
       - name: 'login (ghcr.io)'
         uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7
         with:
-          username: '${{ github.actor }}'
+          username: '${{ github.repository_owner }}'
           password: '${{ secrets.GITHUB_TOKEN }}'
           registry: 'ghcr.io/${{ github.repository_owner }}'
 


### PR DESCRIPTION
Try them in different scheduled workflows to see which single change 
may cause a failure. Also leave the 3rd scheduled workflow unchanged
as a reference.

1. try replacing `github.actor` with `github.repository_owner`. It's 
   kind of odd and accidental how GitHub chooses the `actor` for
   a scheduled   job. Maybe it's the last user who changed the workflow.
   Repo owner is well-defined, try to switch to that instead.

2. try replacing `redhat-actions/podman-login` action with local podman
   command. To remove a dependency and a GHA exception, and pass secrets
   more securely. Also logout manually, replicating what the action did.

The good change(s) will be applied to all workflows.

Follow-up to 00a5a5e17eae4ee9660766805697a2479ed5e0dd #108
Follow-up to 6831a9ea51d3a5b13999beea7c17d4303419693e
Follow-up to 214368a2ed2ed450be888d81f8480f428c9bad29 #102

---

Remaining #102 changes to probe and apply if working:
- local podman combined with github.repository_owner.
- drop seemingly unused logins (docker, quay), while only pushing to ghcr.io.
- replace cosign action with Homebrew cosign install.
- move logins closer to their use.
- add `-d` to cosign verify for docker.io to know more about the flaky failures seen on releases.
