### PR TITLE
GHA/build_ci_multi: test debian/fedora/master in PRs

### DIFF
--- a/.github/workflows/build_ci_multi.yml
+++ b/.github/workflows/build_ci_multi.yml
@@ -75,8 +75,8 @@ jobs:
           podman logout quay.io
           docker logout quay.io
 
-  build_multi_ci:
-    name: 'build_multi_ci'
+  build_ci:
+    name: 'build_ci'
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'install dev deps'
@@ -94,6 +94,57 @@ jobs:
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           podman --version; docker --version; cosign version
+
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+
+      - name: 'build image: master'
+        run: buildah unshare make branch_or_ref=master release_tag=master build_ref_images
+
+      - name: 'test image: master'
+        run: buildah unshare make dist_name=localhost/curl release_tag=master test
+
+      - name: 'security scan image: master'
+        run: |
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+          make image_name=localhost/curl:master scan
+
+      - name: 'build image: dev-debian'
+        run: buildah unshare make branch_or_ref=master release_tag=master build_debian
+
+      - name: 'test image: dev-debian'
+        run: buildah unshare make dist_name=localhost/curl-dev-debian release_tag=master test
+
+      - name: 'security scan image: dev-debian'
+        run: |
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+          make image_name=localhost/curl-dev-debian:master scan
+
+      - name: 'build image: dev-fedora'
+        run: buildah unshare make branch_or_ref=master release_tag=master build_fedora
+
+      - name: 'test image: dev-fedora'
+        run: buildah unshare make dist_name=localhost/curl-dev-fedora release_tag=master test
+
+      - name: 'security scan image: dev-fedora'
+        run: |
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+          make image_name=localhost/curl-dev-fedora:master scan
+
+  build_multi_ci:
+    name: 'build_multi_ci'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: 'install dev deps'
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/{azure-cli.sources,microsoft-prod.list,ondrej-ubuntu-php-noble.sources}
+          sudo apt-get -o Dpkg::Use-Pty=0 update
+          sudo apt-get -o Dpkg::Use-Pty=0 install \
+            qemu-user-static buildah less git make podman clamav clamav-freshclam
+
+      - name: 'install prereqs'
+        run: /home/linuxbrew/.linuxbrew/bin/brew install grype trivy
 
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:

--- a/.github/workflows/build_ci_multi.yml
+++ b/.github/workflows/build_ci_multi.yml
@@ -1,4 +1,4 @@
-name: build_ci_multi_images
+name: build_ci_images
 
 'on':
   pull_request:
@@ -75,8 +75,8 @@ jobs:
           podman logout quay.io
           docker logout quay.io
 
-  build_ci:
-    name: 'build_ci'
+  build_ci_master:
+    name: 'build_ci_master'
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'install dev deps'

--- a/.github/workflows/build_ci_multi.yml
+++ b/.github/workflows/build_ci_multi.yml
@@ -75,8 +75,8 @@ jobs:
           podman logout quay.io
           docker logout quay.io
 
-  build_ci_master:
-    name: 'build_ci_master'
+  master:
+    name: 'Test build: master'
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'install dev deps'
@@ -132,8 +132,8 @@ jobs:
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           make image_name=localhost/curl-dev-fedora:master scan
 
-  build_multi_ci:
-    name: 'build_multi_ci'
+  multi:
+    name: 'Test build: multi'
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'install dev deps'

--- a/.github/workflows/build_latest_release_multi.yml
+++ b/.github/workflows/build_latest_release_multi.yml
@@ -50,10 +50,10 @@ jobs:
       - name: 'build image: multi'
         run: buildah unshare make branch_or_ref="$TAG_REF" release_tag="$REL" multibuild
 
-      - name: 'test image'
+      - name: 'test image: multi'
         run: buildah unshare make dist_name=localhost/curl-multi release_tag="$REL" test
 
-      - name: 'security scan image'
+      - name: 'security scan image: multi'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           make image_name=localhost/curl-multi:"$REL" scan

--- a/.github/workflows/build_master.yml
+++ b/.github/workflows/build_master.yml
@@ -43,10 +43,10 @@ jobs:
       - name: 'build image: master'
         run: buildah unshare make branch_or_ref=master release_tag=master build_ref_images
 
-      - name: 'test image'
+      - name: 'test image: master'
         run: buildah unshare make dist_name=localhost/curl release_tag=master test
 
-      - name: 'security scan image'
+      - name: 'security scan image: master'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           make image_name=localhost/curl:master scan

--- a/.github/workflows/build_master_multi.yml
+++ b/.github/workflows/build_master_multi.yml
@@ -50,10 +50,10 @@ jobs:
       - name: 'build image: multi'
         run: buildah unshare make branch_or_ref="$TAG_REF" release_tag="$REL" multibuild
 
-      - name: 'test image'
+      - name: 'test image: multi'
         run: buildah unshare make dist_name=localhost/curl-multi release_tag="$REL" test
 
-      - name: 'security scan image'
+      - name: 'security scan image: multi'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           make image_name=localhost/curl-multi:"$REL" scan

--- a/create_dev_image.sh
+++ b/create_dev_image.sh
@@ -65,14 +65,14 @@ if [ "${branch_or_tag:0:4}" = "curl" ]; then
   # its a tag, retrieve release source
   # shellcheck disable=SC2154
   buildah run "$bdr" /usr/bin/curl -L -o curl.tar.gz "https://github.com/curl/curl/releases/download/${branch_or_tag}/curl-${release_tag}.tar.gz"
-  buildah run "$bdr" tar -xvf curl.tar.gz
+  buildah run "$bdr" tar -xf curl.tar.gz
   buildah run "$bdr" rm curl.tar.gz
   buildah run "$bdr" mv curl-"${release_tag}" /src/curl-"${release_tag}"
   buildah config --workingdir /src/curl-"${release_tag}" "$bdr"
 else
   # its a branch, retrieve archive source
   buildah run "$bdr" /usr/bin/curl -L -o curl.tar.gz "https://github.com/curl/curl/archive/refs/heads/${branch_or_tag}.tar.gz"
-  buildah run "$bdr" tar -xvf curl.tar.gz
+  buildah run "$bdr" tar -xf curl.tar.gz
   buildah run "$bdr" rm curl.tar.gz
   buildah run "$bdr" mv curl-"${branch_or_tag}" /src/curl-"${branch_or_tag}"
   buildah config --workingdir /src/curl-"${branch_or_tag}" "$bdr"

--- a/create_dev_image.sh
+++ b/create_dev_image.sh
@@ -81,8 +81,8 @@ fi
 # build curl
 buildah run "$bdr" autoreconf -fi
 # shellcheck disable=SC2086
-buildah run "$bdr" ./configure --disable-dependency-tracking ${build_opts}
-buildah run "$bdr" make "-j$(nproc)"
+time buildah run "$bdr" ./configure --disable-dependency-tracking ${build_opts}
+time buildah run "$bdr" make "-j$(nproc)"
 
 # run tests
 if [[ $run_tests -eq 1 ]]; then

--- a/create_dev_image.sh
+++ b/create_dev_image.sh
@@ -78,7 +78,7 @@ else
   buildah config --workingdir /src/curl-"${branch_or_tag}" "$bdr"
 fi
 
-parallel=5
+parallel=$(nproc)
 echo "parallel: ${parallel}"
 
 # build curl

--- a/create_dev_image.sh
+++ b/create_dev_image.sh
@@ -82,15 +82,15 @@ fi
 buildah run "$bdr" autoreconf -fi
 # shellcheck disable=SC2086
 time buildah run "$bdr" ./configure --disable-dependency-tracking ${build_opts}
-time buildah run "$bdr" make -j5
+time buildah run "$bdr" make "-j$(nproc)"
 
 # run tests
 if [[ $run_tests -eq 1 ]]; then
-  buildah run "$bdr" make -j5 test
+  buildah run "$bdr" make "-j$(nproc)" test
 fi
 
 # install curl in /build
-buildah run "$bdr" make -j5 install DESTDIR="/build"
+buildah run "$bdr" make "-j$(nproc)" install DESTDIR="/build"
 
 # label image
 buildah config --label org.opencontainers.image.source="https://github.com/curl/curl-container" "$bdr"

--- a/create_dev_image.sh
+++ b/create_dev_image.sh
@@ -82,15 +82,15 @@ fi
 buildah run "$bdr" autoreconf -fi
 # shellcheck disable=SC2086
 time buildah run "$bdr" ./configure --disable-dependency-tracking ${build_opts}
-time buildah run "$bdr" make "-j$(nproc)"
+time buildah run "$bdr" make -j5
 
 # run tests
 if [[ $run_tests -eq 1 ]]; then
-  buildah run "$bdr" make test
+  buildah run "$bdr" make -j5 test
 fi
 
 # install curl in /build
-buildah run "$bdr" make DESTDIR="/build" install "-j$(nproc)"
+buildah run "$bdr" make -j5 install DESTDIR="/build"
 
 # label image
 buildah config --label org.opencontainers.image.source="https://github.com/curl/curl-container" "$bdr"

--- a/create_dev_image.sh
+++ b/create_dev_image.sh
@@ -65,14 +65,14 @@ if [ "${branch_or_tag:0:4}" = "curl" ]; then
   # its a tag, retrieve release source
   # shellcheck disable=SC2154
   buildah run "$bdr" /usr/bin/curl -L -o curl.tar.gz "https://github.com/curl/curl/releases/download/${branch_or_tag}/curl-${release_tag}.tar.gz"
-  buildah run "$bdr" tar -xf curl.tar.gz
+  buildah run "$bdr" tar -xvf curl.tar.gz
   buildah run "$bdr" rm curl.tar.gz
   buildah run "$bdr" mv curl-"${release_tag}" /src/curl-"${release_tag}"
   buildah config --workingdir /src/curl-"${release_tag}" "$bdr"
 else
   # its a branch, retrieve archive source
   buildah run "$bdr" /usr/bin/curl -L -o curl.tar.gz "https://github.com/curl/curl/archive/refs/heads/${branch_or_tag}.tar.gz"
-  buildah run "$bdr" tar -xf curl.tar.gz
+  buildah run "$bdr" tar -xvf curl.tar.gz
   buildah run "$bdr" rm curl.tar.gz
   buildah run "$bdr" mv curl-"${branch_or_tag}" /src/curl-"${branch_or_tag}"
   buildah config --workingdir /src/curl-"${branch_or_tag}" "$bdr"

--- a/create_dev_image.sh
+++ b/create_dev_image.sh
@@ -78,24 +78,24 @@ else
   buildah config --workingdir /src/curl-"${branch_or_tag}" "$bdr"
 fi
 
-parallel=$(nproc)
+parallel=1
 
 # build curl
 buildah run "$bdr" autoreconf -fi
 # shellcheck disable=SC2086
 time buildah run "$bdr" ./configure --disable-dependency-tracking ${build_opts}
 echo "||-j${parallel}||"
-time buildah run "$bdr" echo '-j${parallel}'
-time buildah run "$bdr" echo "-j${parallel}"
-time buildah run "$bdr" make '-j${parallel}'
+time buildah run "$bdr" echo '-j$(nproc)'
+time buildah run "$bdr" echo "-j$(nproc)"
+time buildah run "$bdr" make '-j$(nproc)'
 
 # run tests
 if [[ $run_tests -eq 1 ]]; then
-  buildah run "$bdr" make '-j${parallel}' test
+  buildah run "$bdr" make '-j$(nproc)' test
 fi
 
 # install curl in /build
-buildah run "$bdr" make '-j${parallel}' install DESTDIR="/build"
+buildah run "$bdr" make '-j$(nproc)' install DESTDIR="/build"
 
 # label image
 buildah config --label org.opencontainers.image.source="https://github.com/curl/curl-container" "$bdr"

--- a/create_dev_image.sh
+++ b/create_dev_image.sh
@@ -78,19 +78,24 @@ else
   buildah config --workingdir /src/curl-"${branch_or_tag}" "$bdr"
 fi
 
+parallel=$(nproc)
+
 # build curl
 buildah run "$bdr" autoreconf -fi
 # shellcheck disable=SC2086
 time buildah run "$bdr" ./configure --disable-dependency-tracking ${build_opts}
-time buildah run "$bdr" make "-j$(nproc)"
+echo "||-j${parallel}||"
+time buildah run "$bdr" echo '-j${parallel}'
+time buildah run "$bdr" echo "-j${parallel}"
+time buildah run "$bdr" make '-j${parallel}'
 
 # run tests
 if [[ $run_tests -eq 1 ]]; then
-  buildah run "$bdr" make "-j$(nproc)" test
+  buildah run "$bdr" make '-j${parallel}' test
 fi
 
 # install curl in /build
-buildah run "$bdr" make "-j$(nproc)" install DESTDIR="/build"
+buildah run "$bdr" make '-j${parallel}' install DESTDIR="/build"
 
 # label image
 buildah config --label org.opencontainers.image.source="https://github.com/curl/curl-container" "$bdr"

--- a/create_dev_image.sh
+++ b/create_dev_image.sh
@@ -78,12 +78,7 @@ else
   buildah config --workingdir /src/curl-"${branch_or_tag}" "$bdr"
 fi
 
-if [[ -n "${platform}" && (! "${platform}" =~ /(386|amd64)) ]]; then
-  parallel=1
-else
-  parallel=$(nproc)
-fi
-
+parallel=5
 echo "parallel: ${parallel}"
 
 # build curl

--- a/create_multi.sh
+++ b/create_multi.sh
@@ -26,7 +26,7 @@ buildah manifest create "curl-base-multi:${release_tag}"
 buildah manifest create "curl-multi:${release_tag}"
 
 # loop through supported arches
-for IMGTAG in "linux/386" "linux/arm/v7" "linux/amd64" "linux/arm64" "linux/ppc64le"; do
+for IMGTAG in "linux/386" "linux/amd64" "linux/arm64" "linux/arm/v7" "linux/ppc64le"; do
   pathname="${IMGTAG////-}"
   echo "building $IMGTAG : $pathname"
   ./create_dev_image.sh "$IMGTAG" "${base}" "${compiler}" "$dev_deps" "$build_opts" "${branch_or_ref}" "curl-dev-${pathname}:${release_tag}" 0

--- a/create_multi.sh
+++ b/create_multi.sh
@@ -26,7 +26,7 @@ buildah manifest create "curl-base-multi:${release_tag}"
 buildah manifest create "curl-multi:${release_tag}"
 
 # loop through supported arches
-for IMGTAG in "linux/386" "linux/amd64" "linux/arm64" "linux/arm/v7" "linux/ppc64le"; do
+for IMGTAG in "linux/386" "linux/arm64" "linux/amd64" "linux/arm/v7" "linux/ppc64le"; do
   pathname="${IMGTAG////-}"
   echo "building $IMGTAG : $pathname"
   ./create_dev_image.sh "$IMGTAG" "${base}" "${compiler}" "$dev_deps" "$build_opts" "${branch_or_ref}" "curl-dev-${pathname}:${release_tag}" 0

--- a/create_multi.sh
+++ b/create_multi.sh
@@ -26,7 +26,7 @@ buildah manifest create "curl-base-multi:${release_tag}"
 buildah manifest create "curl-multi:${release_tag}"
 
 # loop through supported arches
-for IMGTAG in "linux/386" "linux/arm64" "linux/amd64" "linux/arm/v7" "linux/ppc64le"; do
+for IMGTAG in "linux/386" "linux/amd64" "linux/arm64" "linux/arm/v7" "linux/ppc64le"; do
   pathname="${IMGTAG////-}"
   echo "building $IMGTAG : $pathname"
   ./create_dev_image.sh "$IMGTAG" "${base}" "${compiler}" "$dev_deps" "$build_opts" "${branch_or_ref}" "curl-dev-${pathname}:${release_tag}" 0


### PR DESCRIPTION
To make it easy to test build changes in PR, without merging
to the main first.

Also:
- adjust workflow description. it's not only multi after this patch.
- sync step descriptions for multi builds.
- log configure and build time.
- log make `-j` value.
- apply `-j` to `make test` (not currently used).
- make `-j` the first option (formatting).
- create_multi.sh: build amd4 before non-native ones.
  (to build native archs first)
- create_multi.sh: build arm64 before arm32.
  (to build popular archs first)
 
FTR multi build times:
arch          |  configure |       make
:------------ | ---------: | ---------:
linux/386     |  0m14.087s |  1m30.626s
linux/amd64   |  0m12.857s |  1m17.993s
linux/arm64   |  4m03.589s | 19m49.995s
linux/arm/v7  |  3m56.205s | 19m53.784s
linux/ppc64le |  4m03.762s | 19m30.887s
