### PR TITLE
fix: use numeric UID/GID 8888 for curl_user and curl_group

### DIFF
--- a/create_appliance_image.sh
+++ b/create_appliance_image.sh
@@ -32,8 +32,8 @@ buildah config --label name="${image_name}" "$ctr"
 buildah config --label version="${release_tag}" "$ctr"
 buildah config --label docker.cmd="podman run -it quay.io/curl/${image_name}:${release_tag}" "$ctr"
 
-# assumes base image has setup curl_user
-buildah config --user curl_user "$ctr"
+# assumes base image has setup curl_user with numeric id 8888
+buildah config --user 8888 "$ctr"
 
 # label image
 buildah config --label org.opencontainers.image.source="https://github.com/curl/curl-container" "$ctr"

--- a/create_base_image.sh
+++ b/create_base_image.sh
@@ -85,9 +85,12 @@ buildah run "$ctr" ln -s /usr/lib/libcurl.so.4 /usr/lib/libcurl.so
 buildah run "$ctr" curl https://curl.se/ca/cacert.pem -L -o /cacert.pem
 buildah config --env CURL_CA_BUNDLE="/cacert.pem" "$ctr"
 
-# setup curl_group and curl_user though it is not used directly in this image
-buildah run "$ctr" addgroup -S curl_group
-buildah run "$ctr" adduser -S curl_user -G curl_group
+# setup curl_group and curl_user with explicit numeric GID/UID (8888)
+# using numeric id ensures consistent identity across images and runtimes,
+# and satisfies Kubernetes runAsNonRoot enforcement without requiring
+# a username lookup (which can fail in distroless/scratch environments)
+buildah run "$ctr" addgroup -S -g 8888 curl_group
+buildah run "$ctr" adduser -S -u 8888 curl_user -G curl_group
 
 # set entrypoint
 buildah config --cmd curl "$ctr"


### PR DESCRIPTION
Fixes #25

## What

Pin `curl_group` GID and `curl_user` UID to `8888` in `create_base_image.sh`, and switch `create_appliance_image.sh` from `--user curl_user` to `--user 8888`.

## Why

Using a symbolic username in the `USER` directive can fail in minimal or distroless environments where `/etc/passwd` is not present — the runtime cannot resolve the name to a UID and the container may fail to start.

Pinning to a fixed numeric id (`8888`):
- Works reliably in scratch/distroless images
- Satisfies Kubernetes `runAsNonRoot: true` enforcement, which checks that the effective UID is non-zero (numeric lookup, not name-based)
- Gives predictable, consistent identity across all image variants and runtimes
- Follows OCI and Kubernetes best-practice guidance to always specify `USER` as a numeric id

The UID/GID `8888` is in the unprivileged range, avoids conflicts with typical system UIDs, and is consistent with common container hardening practices.