### PR TITLE
Makefile: bump alpine base 3.23.4 -> 3.24.1 (openssl CVE-2026-34182)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ container_ids=`buildah ls --format "{{.ContainerID}}"`
 # default settings for official curl images
 debian_base=docker.io/debian
 fedora_base=docker.io/fedora
-base=docker.io/alpine:3.23.4
+base=docker.io/alpine:3.24.1
 arch=""
 compiler="gcc"
 dev_deps="git zsh curl build-base libtool autoconf automake perl openssl libssh2 libssh2-dev libssh2-static nghttp2-dev brotli brotli-dev zstd-dev krb5-dev libpsl-dev python3 python3-dev stunnel nghttp2"


### PR DESCRIPTION
## What

Bump the alpine base for the official curl images from `3.23.4` to `3.24.1` in the `Makefile`.

## Why

`alpine:3.23.4` (2026-04-15) ships `openssl` / `libssl3` / `libcrypto3` at `3.5.6-r0`, which is affected by **CVE-2026-34182** (CRITICAL) — insufficient input validation on the cipher and tag length fields of `AuthEnvelopedData` containers in OpenSSL's CMS processing. Fixed in `3.5.7-r0`.

- The 3.23 series has no newer point release (`3.23.4` is the latest), so there is nothing to bump to within 3.23.
- `alpine:3.24.1` (2026-06-16) is the current stable release and ships the patched `openssl 3.5.7-r0`.

This refreshes the base image layer so rebuilt `curl` / `curl-base` images are no longer flagged for CVE-2026-34182.

Ref: https://security.alpinelinux.org/vuln/CVE-2026-34182

🤖 Generated with [Claude Code](https://claude.com/claude-code)