### PR TITLE
Makefile: fix `container_id` used in the `clean` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := all
 
-container_ids=`buildah ls --format "{{.ContainerID}}"`
+container_ids = $(shell buildah ls --format "{{.ContainerID}}")
 
 # default settings for official curl images
 debian_base=docker.io/debian


### PR DESCRIPTION
By replacing backticks (that are taken literally by GNU Make), with
`$(shell)` to run and expand the command.

Spotted by GitHub Code Quality